### PR TITLE
chore: fixed ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,5 +29,5 @@ jobs:
       shell: bash
       run: |
         dotnet tool install --global dotnet-releaser
-        dotnet-releaser run --github-token "${{secrets.GITHUB_TOKEN}}" src/dotnet-releaser.toml
+        dotnet-releaser run --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml
         


### PR DESCRIPTION
Should fix the workflow error:
Configuration file `/home/runner/work/BB84.Notifications/BB84.Notifications/src/dotnet-releaser.toml' not found.