### PR TITLE
feat: targeting multiple frameworks

### DIFF
--- a/BB84.Notifications.sln
+++ b/BB84.Notifications.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		dotnet-releaser.toml = dotnet-releaser.toml
 		LICENSE = LICENSE
 		PublicKey.snk = PublicKey.snk

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
@@ -58,7 +58,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="!$(MSBuildProjectName.EndsWith('Tests'))">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+    <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
+        <Using Remove="System.Net.Http" />
+    </ItemGroup>
+</Project>

--- a/tests/BB84.NotificationsTests/NotifyCollectionBaseTests.cs
+++ b/tests/BB84.NotificationsTests/NotifyCollectionBaseTests.cs
@@ -9,7 +9,7 @@ namespace BB84.NotificationsTests;
 [TestClass]
 public sealed partial class NotifyCollectionBaseTests
 {
-  private class MyCollection : NotifyCollectionBase, ICollection<string>
+  private sealed class MyCollection : NotifyCollectionBase, ICollection<string>
   {
     private readonly Collection<string> _collection;
 


### PR DESCRIPTION
- added support for `netstandard2.0`
- added support for `net462`
- added support for `net6.0`
- `Directory.Build.targets` file added
- fixed one unit test

closes #14 