### PR TITLE
chore: version bump to `2.0.0`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
 
   <PropertyGroup>
-    <VersionMajor>1</VersionMajor>
-    <VersionMinor>8</VersionMinor>
-    <VersionPatch>2</VersionPatch>
+    <VersionMajor>2</VersionMajor>
+    <VersionMinor>0</VersionMinor>
+    <VersionPatch>0</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
     <VersionSuffix Condition="$(Configuration.Equals('Debug'))">Development</VersionSuffix>
   </PropertyGroup>


### PR DESCRIPTION
closes #61