### PR TITLE
chore: version bump to `3.0.0`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
 
   <PropertyGroup>
-    <VersionMajor>2</VersionMajor>
-    <VersionMinor>1</VersionMinor>
-    <VersionPatch>1</VersionPatch>
+    <VersionMajor>3</VersionMajor>
+    <VersionMinor>0</VersionMinor>
+    <VersionPatch>0</VersionPatch>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>
     <VersionSuffix Condition="$(Configuration.Equals('Debug'))">Development</VersionSuffix>
   </PropertyGroup>


### PR DESCRIPTION
changes:
- version bumped to `3.0.0`

closes #78 