### PR TITLE
fix: typo in extension methods

### DIFF
--- a/src/BB84.Notifications/Commands/AsyncActionCommand.cs
+++ b/src/BB84.Notifications/Commands/AsyncActionCommand.cs
@@ -46,7 +46,7 @@ public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecut
 
   /// <inheritdoc/>
   public void Execute(object? parameter)
-    => ExecuteAsync().ToSaveVoid(handler);
+    => ExecuteAsync().FireAndForgetSafeAsync(handler);
 
   /// <inheritdoc/>
   public void RaiseCanExecuteChanged()
@@ -80,7 +80,7 @@ public sealed class AsyncActionCommand<T>(Func<T, Task> execute, Func<T, bool>? 
 
   /// <inheritdoc/>
   public void Execute(object? parameter)
-    => ExecuteAsync((T)parameter!).ToSaveVoid(handler);
+    => ExecuteAsync((T)parameter!).FireAndForgetSafeAsync(handler);
 
   /// <inheritdoc/>
   public async Task ExecuteAsync(T parameter)

--- a/src/BB84.Notifications/Extensions/TaskExtensions.cs
+++ b/src/BB84.Notifications/Extensions/TaskExtensions.cs
@@ -9,11 +9,11 @@ public static class TaskExtensions
 {
   /// <summary>
   /// Awaits the provided <paramref name="task"/>, uses the exception <paramref name="handler"/>
-  /// if an <see cref="Exception"/> occured and returns <see cref="void"/>.
+  /// if an <see cref="Exception"/> occurs and returns <see cref="void"/>.
   /// </summary>
   /// <param name="task">The task to await.</param>
   /// <param name="handler">Sends the exception to an exception handler.</param>
-  public static async void ToSaveVoid(this Task task, IExceptionHandler? handler = null)
+  public static async void FireAndForgetSafeAsync(this Task task, IExceptionHandler? handler = null)
   {
     try
     {
@@ -21,7 +21,7 @@ public static class TaskExtensions
     }
     catch (Exception ex)
     {
-      handler?.Handle(ex);
+      handler?.HandleError(ex);
     }
   }
 }

--- a/src/BB84.Notifications/Interfaces/Components/IExceptionHandler.cs
+++ b/src/BB84.Notifications/Interfaces/Components/IExceptionHandler.cs
@@ -9,5 +9,5 @@ public interface IExceptionHandler
   /// If an error occurs, it send the exception to an error handler.
   /// </summary>
   /// <param name="exception">The exception to handle.</param>
-  void Handle(Exception exception);
+  void HandleError(Exception exception);
 }

--- a/tests/BB84.NotificationsTests/Extensions/TaskExtensionsTests.cs
+++ b/tests/BB84.NotificationsTests/Extensions/TaskExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿using BB84.Notifications.Extensions;
+using BB84.Notifications.Interfaces.Components;
+
+namespace BB84.NotificationsTests.Extensions;
+
+[TestClass]
+[SuppressMessage("Usage", "CA2201", Justification = "UnitTest")]
+public sealed class TaskExtensionsTests
+{
+  [TestMethod]
+  public void FireAndForgetSafeAsyncTest()
+  {
+    Task task = Task.Factory.StartNew(() => { });
+
+    task.FireAndForgetSafeAsync();
+
+    Assert.IsNotNull(task);
+  }
+
+  [TestMethod]
+  public void FireAndForgetSafeAsyncExceptionHandledTest()
+  {
+    VoidHandler handler = new();
+    Task task = Task.Factory.StartNew(() => throw new Exception(""));
+
+    task.FireAndForgetSafeAsync(handler);
+  }
+
+  private sealed class VoidHandler : IExceptionHandler
+  {
+    public void HandleError(Exception exception) { }
+  }
+}


### PR DESCRIPTION
changes:
- renamed the method to `FireAndForgetSafeAsync`
- added some unit testing

closes #107