### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BB84.Notifications/security/code-scanning/2](https://github.com/BoBoBaSs84/BB84.Notifications/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, sets up .NET, restores, builds, and tests, it does not require any write permissions. The minimal and recommended setting is `contents: read`, which allows the workflow to read repository contents but not modify them. This should be added at the top level of the workflow file (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
