### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
+      packages: write
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +29,9 @@ jobs:
         dotnet-releaser run --nuget-token "${{secrets.NUGET_TOKEN}}" --github-token "${{secrets.GITHUB_TOKEN}}" dotnet-releaser.toml
 
   docs:
+    permissions:
+      contents: read
+      pages: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/BoBoBaSs84/BB84.Notifications/security/code-scanning/3](https://github.com/BoBoBaSs84/BB84.Notifications/security/code-scanning/3)

To fix the problem, you should add an explicit `permissions` block to the workflow. This can be done at the root level (to apply to all jobs) or at the job level (to tailor permissions for each job). The best approach is to set the minimal permissions required for each job. For the `publish` job, which publishes NuGet packages and interacts with GitHub releases, you likely need `contents: write` and possibly `packages: write` and `pull-requests: write` if it creates releases or modifies PRs. For the `docs` job, which deploys documentation using `peaceiris/actions-gh-pages`, you need `pages: write` and `contents: read`. If unsure, start with the minimal permissions and expand only as needed.

You should edit `.github/workflows/cd.yml` and add a `permissions` block for each job, specifying only the required permissions. No additional imports or definitions are needed, as this is a YAML configuration change.