### PR TITLE
feat: Refactor validation logic and fixed typo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup Label="Versioning">
     <VersionMajor>4</VersionMajor>
-    <VersionMinor>1</VersionMinor>
+    <VersionMinor>2</VersionMinor>
     <VersionPatch>$([System.DateTime]::UtcNow.ToString("MMdd"))</VersionPatch>
     <VersionRevision>$([System.DateTime]::UtcNow.TimeOfDay.TotalMinutes.ToString("0"))</VersionRevision>
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(VersionRevision)</VersionPrefix>

--- a/src/BB84.Notifications/ValidatableObject.cs
+++ b/src/BB84.Notifications/ValidatableObject.cs
@@ -62,7 +62,7 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
     if (!EqualityComparer<T>.Default.Equals(fieldValue, newValue))
     {
       SetProperty(ref fieldValue, newValue, propertyName);
-      Vaildate(newValue, propertyName);
+      Validate(newValue, propertyName);
     }
   }
 
@@ -92,7 +92,7 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   /// <returns>
   /// <see langword="true"/> if the object passes validation; otherwise, <see langword="false"/>.
   /// </returns>
-  protected bool Validate()
+  protected virtual bool Validate()
   {
     ValidationContext context = new(this);
     List<ValidationResult> results = [];
@@ -125,7 +125,7 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   /// <param name="propertyName">
   /// The name of the property being validated. This must match the name of the property in the class.
   /// </param>
-  protected void Vaildate<T>(T value, string propertyName)
+  protected virtual void Validate<T>(T value, string propertyName)
   {
     ValidationContext context = new(this) { MemberName = propertyName };
     List<ValidationResult> results = [];
@@ -154,7 +154,7 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   /// <param name="errorMessage">
   /// The error message to associate with the property. Can be null, in which case no message is added.
   /// </param>
-  private void AddError(string propertyName, string? errorMessage)
+  protected void AddError(string propertyName, string? errorMessage)
   {
     if (_errors.ContainsKey(propertyName).Equals(false))
       _errors.Add(propertyName, []);


### PR DESCRIPTION
**Changes:**

- Bump minor version in `Directory.Build.props` from 1 to 2.
- Fix typo: rename `Vaildate` to `Validate` in `ValidatableObject.cs`.
- Make `Validate` and `Validate<T>` virtual for extensibility.
- Change `AddError` from private to protected for subclass access.

closes #185 