### PR TITLE
feat: add custom `IEqualityComparer<T>` support to properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Concrete implementation of a notifiable property with implicit conversion suppor
 
 **Key Features:**
 
-- Automatic change detection using `EqualityComparer<T>`
+- Automatic change detection using `EqualityComparer<T>` or a custom `IEqualityComparer<T>`
 - Generic event arguments with typed values
 - Implicit conversion operators
 - Thread-safe property updates
@@ -169,7 +169,7 @@ Abstract base class providing property change infrastructure.
 
 **Key Features:**
 
-- `SetProperty` method for automatic change detection
+- `SetProperty` method for automatic change detection (default or custom `IEqualityComparer<T>`)
 - Attribute-based notification propagation
 - Reflection optimization with caching
 - Support for computed properties
@@ -273,7 +273,6 @@ public class PersonViewModel : NotifiableObject
 ```csharp
 public class ProductViewModel
 {
-    public INotifiableProperty<string> Name { get; set; } = new NotifiableProperty<string>("Default Name");
     public INotifiableProperty<decimal> Price { get; set; } = new NotifiableProperty<decimal>(0m);
     public INotifiableProperty<int> Quantity { get; set; } = new NotifiableProperty<int>(1);
 
@@ -282,6 +281,42 @@ public class ProductViewModel
         // Subscribe to property changes
         Name.PropertyChanged += (s, e) => Console.WriteLine($"Name changed to: {Name.Value}");
         Price.PropertyChanged += (s, e) => Console.WriteLine($"Price changed to: {Price.Value:C}");
+    }
+}
+```
+
+### Custom Equality Comparer
+
+Supply a custom `IEqualityComparer<T>` to control when a change is considered meaningful:
+
+```csharp
+// NotifiableProperty<T> — case-insensitive string comparison
+INotifiableProperty<string> tag = new NotifiableProperty<string>("hello", StringComparer.OrdinalIgnoreCase);
+tag.Value = "HELLO"; // no event raised — considered equal
+
+// NotifiableObject — per-property comparer in SetProperty
+public class DocumentViewModel : NotifiableObject
+{
+    private string _title = string.Empty;
+
+    public string Title
+    {
+        get => _title;
+        // case-insensitive: "Hello" and "hello" are the same title
+        set => SetProperty(ref _title, value, StringComparer.OrdinalIgnoreCase);
+    }
+}
+
+// ValidatableObject — same pattern for SetPropertyAndValidate
+public class UserViewModel : ValidatableObject
+{
+    private string _email = string.Empty;
+
+    [Required, EmailAddress]
+    public string Email
+    {
+        get => _email;
+        set => SetPropertyAndValidate(ref _email, value, StringComparer.OrdinalIgnoreCase);
     }
 }
 ```
@@ -609,16 +644,16 @@ The library is designed to minimize memory allocations:
 
 ### Key Classes
 
-| Class                   | Description                                | Key Features                             |
-| ----------------------- | ------------------------------------------ | ---------------------------------------- |
-| `NotifiableProperty<T>` | Generic property with change notifications | Implicit operators, typed events         |
-| `ReversibleProperty<T>` | Property with value history                | Undo/redo, configurable history          |
-| `NotifiableObject`      | Base class for notifiable objects          | SetProperty, attribute support           |
-| `NotifiableCollection`      | Base class for notifiable collections          | Before/after events, typed notifications |
-| `NotifiableCollection<T>`   | Generic ready-to-use observable list           | `IList<T>`, `IReadOnlyList<T>`, full notifications |
-| `ValidatableObject`     | Base class with validation                 | Data annotations, error notifications    |
-| `ActionCommand`         | Synchronous command implementation         | CanExecute logic, parameter support      |
-| `AsyncActionCommand`    | Asynchronous command implementation        | Exception handling, cancellation         |
+| Class                     | Description                                | Key Features                                       |
+| ------------------------- | ------------------------------------------ | -------------------------------------------------- |
+| `NotifiableProperty<T>`   | Generic property with change notifications | Implicit operators, typed events                   |
+| `ReversibleProperty<T>`   | Property with value history                | Undo/redo, configurable history                    |
+| `NotifiableObject`        | Base class for notifiable objects          | SetProperty, attribute support                     |
+| `NotifiableCollection`    | Base class for notifiable collections      | Before/after events, typed notifications           |
+| `NotifiableCollection<T>` | Generic ready-to-use observable list       | `IList<T>`, `IReadOnlyList<T>`, full notifications |
+| `ValidatableObject`       | Base class with validation                 | Data annotations, error notifications              |
+| `ActionCommand`           | Synchronous command implementation         | CanExecute logic, parameter support                |
+| `AsyncActionCommand`      | Asynchronous command implementation        | Exception handling, cancellation                   |
 
 ### Event Types
 

--- a/src/BB84.Notifications/NotifiableObject.cs
+++ b/src/BB84.Notifications/NotifiableObject.cs
@@ -63,6 +63,37 @@ public abstract class NotifiableObject : INotifiableObject
   }
 
   /// <summary>
+  /// Updates the specified field with a new value using a custom equality comparer and raises
+  /// property change notifications.
+  /// </summary>
+  /// <remarks>
+  /// This method behaves identically to <see cref="SetProperty{T}(ref T, T, string)"/> but uses
+  /// the supplied <paramref name="comparer"/> instead of <see cref="EqualityComparer{T}.Default"/>
+  /// to determine whether the value has actually changed.
+  /// </remarks>
+  /// <typeparam name="T">The type of the property being updated.</typeparam>
+  /// <param name="fieldValue">A reference to the backing field of the property.</param>
+  /// <param name="newValue">The new value to assign to the property.</param>
+  /// <param name="comparer">The equality comparer used to compare the current and new values.</param>
+  /// <param name="propertyName">
+  /// The name of the property being updated.
+  /// This parameter is optional and automatically provided by the compiler if not explicitly specified.
+  /// </param>
+  protected void SetProperty<T>(ref T fieldValue, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string propertyName = "")
+  {
+    if (!comparer.Equals(fieldValue, newValue))
+    {
+      RaisePropertyChanging(propertyName, fieldValue);
+      RaiseChangingAttribute(propertyName);
+
+      fieldValue = newValue;
+
+      RaisePropertyChanged(propertyName, newValue);
+      RaiseChangedAttribute(propertyName);
+    }
+  }
+
+  /// <summary>
   /// Notifies subscribers that a property value has changed.
   /// </summary>
   /// <remarks>

--- a/src/BB84.Notifications/NotifiableProperty.cs
+++ b/src/BB84.Notifications/NotifiableProperty.cs
@@ -22,7 +22,17 @@ namespace BB84.Notifications;
 /// <param name="value">The initial value of the property.</param>
 public sealed class NotifiableProperty<T>(T value) : INotifiableProperty<T>
 {
+  private readonly IEqualityComparer<T> _comparer = EqualityComparer<T>.Default;
   private T _value = value;
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="NotifiableProperty{T}"/> class with an initial
+  /// value and a custom equality comparer.
+  /// </summary>
+  /// <param name="value">The initial value of the property.</param>
+  /// <param name="comparer">The equality comparer used to determine whether the value has changed.</param>
+  public NotifiableProperty(T value, IEqualityComparer<T> comparer) : this(value)
+    => _comparer = comparer;
 
   /// <inheritdoc/>
   public bool IsDefault => EqualityComparer<T>.Default.Equals(_value, default!);
@@ -57,7 +67,7 @@ public sealed class NotifiableProperty<T>(T value) : INotifiableProperty<T>
   /// <param name="newValue">The new value to assign to the property.</param>
   private void SetProperty(ref T fieldValue, T newValue)
   {
-    if (!EqualityComparer<T>.Default.Equals(fieldValue, newValue))
+    if (!_comparer.Equals(fieldValue, newValue))
     {
       PropertyChanging?.Invoke(this, new PropertyChangingEventArgs<T>(fieldValue));
       fieldValue = newValue;

--- a/src/BB84.Notifications/ValidatableObject.cs
+++ b/src/BB84.Notifications/ValidatableObject.cs
@@ -67,6 +67,30 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   }
 
   /// <summary>
+  /// Sets the specified property to a new value using a custom equality comparer and performs validation.
+  /// </summary>
+  /// <remarks>
+  /// This method behaves identically to <see cref="SetPropertyAndValidate{T}(ref T, T, string)"/> but
+  /// uses the supplied <paramref name="comparer"/> instead of <see cref="EqualityComparer{T}.Default"/>
+  /// to determine whether the value has actually changed.
+  /// </remarks>
+  /// <typeparam name="T">The type of the property value.</typeparam>
+  /// <param name="fieldValue">A reference to the backing field of the property.</param>
+  /// <param name="newValue">The new value to assign to the property.</param>
+  /// <param name="comparer">The equality comparer used to compare the current and new values.</param>
+  /// <param name="propertyName">
+  /// The name of the property being set. This parameter is optional and defaults to the caller's member name.
+  /// </param>
+  protected void SetPropertyAndValidate<T>(ref T fieldValue, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string propertyName = "")
+  {
+    if (!comparer.Equals(fieldValue, newValue))
+    {
+      SetProperty(ref fieldValue, newValue, comparer, propertyName);
+      Validate(newValue, propertyName);
+    }
+  }
+
+  /// <summary>
   /// Raises the <see cref="ErrorsChanged"/> event to notify subscribers that the validation
   /// errors for a specific property have changed.
   /// </summary>

--- a/tests/BB84.Notifications.Tests/NotifiableObjectTests.Comparer.cs
+++ b/tests/BB84.Notifications.Tests/NotifiableObjectTests.Comparer.cs
@@ -1,0 +1,67 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.Notifications.Components;
+
+namespace BB84.Notifications.Tests;
+
+public sealed partial class NotifiableObjectTests
+{
+  private sealed class TestClassWithComparer : NotifiableObject
+  {
+    private string _property = string.Empty;
+
+    public string Property
+    {
+      get => _property;
+      set => SetProperty(ref _property, value, StringComparer.OrdinalIgnoreCase);
+    }
+  }
+
+  [TestMethod]
+  public void SetPropertyWithComparerDoesNotRaiseWhenEqual()
+  {
+    bool raised = false;
+    TestClassWithComparer testClass = new();
+    testClass.Property = "hello";
+    testClass.PropertyChanged += (sender, e) => raised = true;
+
+    testClass.Property = "HELLO";
+
+    Assert.IsFalse(raised);
+  }
+
+  [TestMethod]
+  public void SetPropertyWithComparerRaisesWhenNotEqual()
+  {
+    string? propertyName = string.Empty;
+    TestClassWithComparer testClass = new();
+    testClass.PropertyChanged += (sender, e) => propertyName = e.PropertyName;
+
+    testClass.Property = "world";
+
+    Assert.AreEqual(nameof(testClass.Property), propertyName);
+  }
+
+  [TestMethod]
+  public void SetPropertyWithComparerChangingRaisesWhenNotEqual()
+  {
+    string? propertyName = string.Empty;
+    string oldValue = string.Empty;
+    TestClassWithComparer testClass = new();
+    testClass.Property = "hello";
+    testClass.PropertyChanging += (sender, e) =>
+    {
+      if (e is PropertyChangingEventArgs<string> sArgs)
+        oldValue = sArgs.Value;
+      propertyName = e.PropertyName;
+    };
+
+    testClass.Property = "world";
+
+    Assert.AreEqual(nameof(testClass.Property), propertyName);
+    Assert.AreEqual("hello", oldValue);
+  }
+}

--- a/tests/BB84.Notifications.Tests/NotifiablePropertyTests.Comparer.cs
+++ b/tests/BB84.Notifications.Tests/NotifiablePropertyTests.Comparer.cs
@@ -1,0 +1,46 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Notifications.Tests;
+
+public sealed partial class NotifiablePropertyTests
+{
+  [TestMethod]
+  public void SetPropertyWithComparerDoesNotRaiseWhenEqual()
+  {
+    bool raised = false;
+    NotifiableProperty<string> property = new("hello", StringComparer.OrdinalIgnoreCase);
+    property.PropertyChanged += (sender, e) => raised = true;
+
+    property.Value = "HELLO";
+
+    Assert.IsFalse(raised);
+  }
+
+  [TestMethod]
+  public void SetPropertyWithComparerRaisesWhenNotEqual()
+  {
+    bool raised = false;
+    NotifiableProperty<string> property = new("hello", StringComparer.OrdinalIgnoreCase);
+    property.PropertyChanged += (sender, e) => raised = true;
+
+    property.Value = "world";
+
+    Assert.IsTrue(raised);
+    Assert.AreEqual("world", property.Value);
+  }
+
+  [TestMethod]
+  public void SetPropertyWithComparerChangingRaisesWhenNotEqual()
+  {
+    bool raised = false;
+    NotifiableProperty<string> property = new("hello", StringComparer.OrdinalIgnoreCase);
+    property.PropertyChanging += (sender, e) => raised = true;
+
+    property.Value = "world";
+
+    Assert.IsTrue(raised);
+  }
+}

--- a/tests/BB84.Notifications.Tests/ValidatableObjectTests.Comparer.cs
+++ b/tests/BB84.Notifications.Tests/ValidatableObjectTests.Comparer.cs
@@ -1,0 +1,49 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.ComponentModel.DataAnnotations;
+
+namespace BB84.Notifications.Tests;
+
+public sealed partial class ValidatableObjectTests
+{
+  private sealed class TestClassWithComparer : ValidatableObject
+  {
+    private string _name = string.Empty;
+
+    [Required, MaxLength(50)]
+    public string Name
+    {
+      get => _name;
+      set => SetPropertyAndValidate(ref _name, value, StringComparer.OrdinalIgnoreCase);
+    }
+  }
+
+  [TestMethod]
+  public void SetPropertyAndValidateWithComparerDoesNotRaiseWhenEqual()
+  {
+    bool raised = false;
+    TestClassWithComparer testClass = new();
+    testClass.Name = "hello";
+    testClass.PropertyChanged += (sender, e) => raised = true;
+
+    testClass.Name = "HELLO";
+
+    Assert.IsFalse(raised);
+  }
+
+  [TestMethod]
+  public void SetPropertyAndValidateWithComparerRaisesWhenNotEqual()
+  {
+    string? propertyName = string.Empty;
+    TestClassWithComparer testClass = new();
+    testClass.PropertyChanged += (sender, e) => propertyName = e.PropertyName;
+
+    testClass.Name = "world";
+
+    Assert.AreEqual(nameof(testClass.Name), propertyName);
+    Assert.AreEqual("world", testClass.Name);
+  }
+}


### PR DESCRIPTION
**Changes:**

- Enable custom comparers for `NotifiableProperty<T>`, `NotifiableObject`, and `ValidatableObject` to control property change detection.
- Updated constructors and added overloads for `SetProperty` and `SetPropertyAndValidate` to accept comparers.
- Extended documentation and usage examples in `README.md`.
- Added tests to verify correct event behavior with custom comparers.
- Updated documentation tables for clarity.

closes #191 