### PR TITLE
feat: add cancellation support to `AsyncActionCommand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Interfaces for asynchronous command execution.
 **Implementations:**
 
 - `ActionCommand` / `ActionCommand<T>` - Synchronous commands
-- `AsyncActionCommand` / `AsyncActionCommand<T>` - Asynchronous commands
+- `AsyncActionCommand` / `AsyncActionCommand<T>` - Asynchronous commands with optional `CancellationToken` support, `Cancel()` method, and bindable `CancelCommand`
 
 ## 🧰 Usage Guide
 
@@ -536,10 +536,11 @@ public class MainViewModel : NotifiableObject
             canExecute: () => !string.IsNullOrEmpty(SearchText)
         );
 
+        // Cancellable async command — receives a CancellationToken automatically
         SearchCommand = new AsyncActionCommand<string>(
-            execute: async (query) => await PerformSearchAsync(query),
-            canExecute: (query) => !IsSearching && !string.IsNullOrWhiteSpace(query),
-            onException: (ex) => Console.WriteLine($"Search failed: {ex.Message}")
+            execute: async (query, ct) => await PerformSearchAsync(query, ct),
+            canExecute: (query) => !string.IsNullOrWhiteSpace(query),
+            action: (ex) => Console.WriteLine($"Search failed: {ex.Message}")
         );
 
         // Update command states when properties change
@@ -553,13 +554,12 @@ public class MainViewModel : NotifiableObject
         };
     }
 
-    private async Task PerformSearchAsync(string query)
+    private async Task PerformSearchAsync(string query, CancellationToken ct)
     {
         IsSearching = true;
         try
         {
-            // Simulate async search
-            await Task.Delay(2000);
+            await Task.Delay(2000, ct);
             // Perform actual search logic here
         }
         finally
@@ -568,6 +568,34 @@ public class MainViewModel : NotifiableObject
         }
     }
 }
+```
+
+### Cancelling an Async Command
+
+```csharp
+// Non-generic variant
+IAsyncActionCommand loadCommand = new AsyncActionCommand(
+    execute: async ct => await LoadDataAsync(ct),
+    canExecute: () => true
+);
+
+// Bind CancelCommand directly in the UI (e.g., a Cancel button)
+// CancelCommand.CanExecute() returns true only while loadCommand is executing
+IActionCommand cancelButton = loadCommand.CancelCommand;
+
+// Programmatic cancellation
+loadCommand.Cancel();
+
+// Check whether cancellation was requested
+bool wasCancelled = loadCommand.IsCancellationRequested;
+
+// Generic variant with parameter
+IAsyncActionCommand<string> searchCommand = new AsyncActionCommand<string>(
+    execute: async (query, ct) => await SearchAsync(query, ct)
+);
+
+await searchCommand.ExecuteAsync("hello");          // uses internal CTS
+await searchCommand.ExecuteAsync("hello", myToken); // linked with external token
 ```
 
 ## 🎛️ Advanced Scenarios

--- a/src/BB84.Notifications/Commands/AsyncActionCommand.cs
+++ b/src/BB84.Notifications/Commands/AsyncActionCommand.cs
@@ -9,14 +9,42 @@ using BB84.Notifications.Interfaces.Commands;
 namespace BB84.Notifications.Commands;
 
 /// <summary>
-/// The async action command class.
+/// Represents an asynchronous command that can be executed and queried for its ability to execute.
 /// </summary>
-/// <param name="execute">The task to execute.</param>
+/// <remarks>
+/// When a <c>Func&lt;CancellationToken, Task&gt;</c> delegate is supplied the command manages its own
+/// <see cref="CancellationTokenSource"/> internally. Call <see cref="Cancel"/> (or execute
+/// <see cref="CancelCommand"/>) to cancel a running operation.
+/// </remarks>
+/// <param name="execute">The task to execute (without cancellation token).</param>
 /// <param name="canExecute">The condition to execute.</param>
 /// <param name="action">The action to invoke if an exception occurs.</param>
 public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecute = null, Action<Exception>? action = null) : IAsyncActionCommand
 {
+  private readonly Func<CancellationToken, Task> _execute = _ => execute();
+  private readonly Func<bool>? _canExecute = canExecute;
+  private readonly Action<Exception>? _action = action;
+
   private bool _isExecuting;
+  private CancellationTokenSource? _cts;
+
+  /// <summary>
+  /// Initializes a new instance of <see cref="AsyncActionCommand"/> with a cancellable execute delegate.
+  /// </summary>
+  /// <param name="execute">The task to execute, accepting a <see cref="CancellationToken"/>.</param>
+  /// <param name="canExecute">The condition to execute.</param>
+  /// <param name="action">The action to invoke if an exception occurs.</param>
+  public AsyncActionCommand(Func<CancellationToken, Task> execute, Func<bool>? canExecute = null, Action<Exception>? action = null)
+    : this(() => execute(CancellationToken.None), canExecute, action)
+  {
+    _execute = execute;
+  }
+
+  /// <inheritdoc/>
+  public bool IsCancellationRequested => _cts?.IsCancellationRequested ?? false;
+
+  /// <inheritdoc/>
+  public IActionCommand CancelCommand => new ActionCommand(Cancel, () => _isExecuting);
 
   /// <inheritdoc/>
   public event EventHandler? CanExecuteChanged;
@@ -26,31 +54,49 @@ public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecut
     => CanExecute(null);
 
   /// <inheritdoc/>
-  public async Task ExecuteAsync()
+  public void Cancel()
   {
-    if (CanExecute())
-    {
-      try
-      {
-        _isExecuting = true;
-        await execute();
-      }
-      finally
-      {
-        _isExecuting = false;
-      }
-    }
-
+    _cts?.Cancel();
     RaiseCanExecuteChanged();
   }
 
   /// <inheritdoc/>
+  public Task ExecuteAsync()
+    => ExecuteAsync(CancellationToken.None);
+
+  /// <inheritdoc/>
+  public async Task ExecuteAsync(CancellationToken cancellationToken)
+  {
+    if (!CanExecute())
+    {
+      RaiseCanExecuteChanged();
+      return;
+    }
+
+    using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    _cts = cts;
+
+    try
+    {
+      _isExecuting = true;
+      RaiseCanExecuteChanged();
+      await _execute(cts.Token);
+    }
+    finally
+    {
+      _isExecuting = false;
+      _cts = null;
+      RaiseCanExecuteChanged();
+    }
+  }
+
+  /// <inheritdoc/>
   public bool CanExecute(object? parameter)
-    => !_isExecuting && (canExecute?.Invoke() ?? true);
+    => !_isExecuting && (_canExecute?.Invoke() ?? true);
 
   /// <inheritdoc/>
   public void Execute(object? parameter)
-    => ExecuteAsync().FireAndForgetSafeAsync(action);
+    => ExecuteAsync().FireAndForgetSafeAsync(_action);
 
   /// <inheritdoc/>
   public void RaiseCanExecuteChanged()
@@ -58,25 +104,58 @@ public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecut
 }
 
 /// <summary>
-/// The async action command class.
+/// Represents an asynchronous command that can be executed with a parameter of type <typeparamref name="T"/>
+/// and queried for its ability to execute.
 /// </summary>
 /// <remarks>
-/// For all commands that need a parameter.
+/// When a <c>Func&lt;T, CancellationToken, Task&gt;</c> delegate is supplied the command manages its own
+/// <see cref="CancellationTokenSource"/> internally. Call <see cref="Cancel"/> (or execute
+/// <see cref="CancelCommand"/>) to cancel a running operation.
 /// </remarks>
 /// <typeparam name="T">The generic type to work with.</typeparam>
-/// <param name="execute">The task to execute.</param>
+/// <param name="execute">The task to execute (without cancellation token).</param>
 /// <param name="canExecute">The condition to execute.</param>
 /// <param name="action">The action to invoke if an exception occurs.</param>
 public sealed class AsyncActionCommand<T>(Func<T, Task> execute, Func<T, bool>? canExecute = null, Action<Exception>? action = null) : IAsyncActionCommand<T>
 {
+  private readonly Func<T, CancellationToken, Task> _execute = (p, _) => execute(p);
+  private readonly Func<T, bool>? _canExecute = canExecute;
+  private readonly Action<Exception>? _action = action;
+
   private bool _isExecuting;
+  private CancellationTokenSource? _cts;
+
+  /// <summary>
+  /// Initializes a new instance of <see cref="AsyncActionCommand{T}"/> with a cancellable execute delegate.
+  /// </summary>
+  /// <param name="execute">The task to execute, accepting a parameter and a <see cref="CancellationToken"/>.</param>
+  /// <param name="canExecute">The condition to execute.</param>
+  /// <param name="action">The action to invoke if an exception occurs.</param>
+  public AsyncActionCommand(Func<T, CancellationToken, Task> execute, Func<T, bool>? canExecute = null, Action<Exception>? action = null)
+    : this((p) => execute(p, CancellationToken.None), canExecute, action)
+  {
+    _execute = execute;
+  }
+
+  /// <inheritdoc/>
+  public bool IsCancellationRequested => _cts?.IsCancellationRequested ?? false;
+
+  /// <inheritdoc/>
+  public IActionCommand CancelCommand => new ActionCommand(Cancel, () => _isExecuting);
 
   /// <inheritdoc/>
   public event EventHandler? CanExecuteChanged;
 
   /// <inheritdoc/>
   public bool CanExecute(T parameter)
-    => !_isExecuting && (canExecute?.Invoke(parameter) ?? true);
+    => !_isExecuting && (_canExecute?.Invoke(parameter) ?? true);
+
+  /// <inheritdoc/>
+  public void Cancel()
+  {
+    _cts?.Cancel();
+    RaiseCanExecuteChanged();
+  }
 
   /// <inheritdoc/>
   public bool CanExecute(object? parameter)
@@ -84,25 +163,36 @@ public sealed class AsyncActionCommand<T>(Func<T, Task> execute, Func<T, bool>? 
 
   /// <inheritdoc/>
   public void Execute(object? parameter)
-    => ExecuteAsync((T)parameter!).FireAndForgetSafeAsync(action);
+    => ExecuteAsync((T)parameter!).FireAndForgetSafeAsync(_action);
 
   /// <inheritdoc/>
-  public async Task ExecuteAsync(T parameter)
+  public Task ExecuteAsync(T parameter)
+    => ExecuteAsync(parameter, CancellationToken.None);
+
+  /// <inheritdoc/>
+  public async Task ExecuteAsync(T parameter, CancellationToken cancellationToken)
   {
-    if (CanExecute(parameter))
+    if (!CanExecute(parameter))
     {
-      try
-      {
-        _isExecuting = true;
-        await execute(parameter);
-      }
-      finally
-      {
-        _isExecuting = false;
-      }
+      RaiseCanExecuteChanged();
+      return;
     }
 
-    RaiseCanExecuteChanged();
+    using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    _cts = cts;
+
+    try
+    {
+      _isExecuting = true;
+      RaiseCanExecuteChanged();
+      await _execute(parameter, cts.Token);
+    }
+    finally
+    {
+      _isExecuting = false;
+      _cts = null;
+      RaiseCanExecuteChanged();
+    }
   }
 
   /// <inheritdoc/>

--- a/src/BB84.Notifications/Interfaces/Commands/IAsyncActionCommand.cs
+++ b/src/BB84.Notifications/Interfaces/Commands/IAsyncActionCommand.cs
@@ -18,16 +18,38 @@ namespace BB84.Notifications.Interfaces.Commands;
 public interface IAsyncActionCommand : ICommand
 {
   /// <summary>
+  /// Gets a value indicating whether cancellation has been requested for the currently executing operation.
+  /// </summary>
+  bool IsCancellationRequested { get; }
+
+  /// <summary>
+  /// Gets an <see cref="IActionCommand"/> that, when executed, cancels the currently running operation.
+  /// </summary>
+  IActionCommand CancelCommand { get; }
+
+  /// <summary>
   /// Defines the method to be called when the command is invoked.
   /// </summary>
   /// <returns><see cref="Task"/></returns>
   Task ExecuteAsync();
 
   /// <summary>
+  /// Defines the method to be called when the command is invoked with the specified cancellation token.
+  /// </summary>
+  /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+  /// <returns><see cref="Task"/></returns>
+  Task ExecuteAsync(CancellationToken cancellationToken);
+
+  /// <summary>
   /// Defines the method that determines whether the command can execute in its current state.
   /// </summary>
   /// <returns>True if this command can be executed, otherwise false.</returns>
   bool CanExecute();
+
+  /// <summary>
+  /// Requests cancellation of the currently executing operation.
+  /// </summary>
+  void Cancel();
 
   /// <summary>
   /// Notifies that the <see cref="ICommand.CanExecuteChanged"/> property has changed.
@@ -47,38 +69,46 @@ public interface IAsyncActionCommand : ICommand
 public interface IAsyncActionCommand<T> : ICommand
 {
   /// <summary>
+  /// Gets a value indicating whether cancellation has been requested for the currently executing operation.
+  /// </summary>
+  bool IsCancellationRequested { get; }
+
+  /// <summary>
+  /// Gets an <see cref="IActionCommand"/> that, when executed, cancels the currently running operation.
+  /// </summary>
+  IActionCommand CancelCommand { get; }
+
+  /// <summary>
   /// Executes an asynchronous operation using the specified parameter.
   /// </summary>
-  /// <remarks>
-  /// This method performs an operation asynchronously and does not return a result.
-  /// The caller is responsible for awaiting the returned <see cref="Task"/> to ensure the operation completes.
-  /// </remarks>
-  /// <param name="parameter">
-  /// The input parameter of type <typeparamref name="T"/> that is required to perform the operation.
-  /// </param>
-  /// <returns>
-  /// A <see cref="Task"/> representing the asynchronous operation.
-  /// </returns>
+  /// <param name="parameter">The input parameter required to perform the operation.</param>
+  /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
   Task ExecuteAsync(T parameter);
+
+  /// <summary>
+  /// Executes an asynchronous operation using the specified parameter and cancellation token.
+  /// </summary>
+  /// <param name="parameter">The input parameter required to perform the operation.</param>
+  /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+  /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+  Task ExecuteAsync(T parameter, CancellationToken cancellationToken);
 
   /// <summary>
   /// Determines whether the command can execute with the specified parameter.
   /// </summary>
-  /// <param name="parameter">
-  /// The parameter to evaluate. This can be used to determine whether the command is valid for execution.
-  /// </param>
+  /// <param name="parameter">The parameter to evaluate.</param>
   /// <returns>
   /// <see langword="true"/> if the command can execute with the specified parameter; otherwise, <see langword="false"/>.
   /// </returns>
   bool CanExecute(T parameter);
 
   /// <summary>
+  /// Requests cancellation of the currently executing operation.
+  /// </summary>
+  void Cancel();
+
+  /// <summary>
   /// Notifies subscribers that the ability to execute the command may have changed.
   /// </summary>
-  /// <remarks>
-  /// This method should be called when the conditions determining whether the command can execute
-  /// have changed. It triggers the <see cref="ICommand.CanExecuteChanged"/> event, allowing UI
-  /// elements bound to the command to update their enabled state.
-  /// </remarks>
   void RaiseCanExecuteChanged();
 }

--- a/tests/BB84.Notifications.Tests/Commands/AsyncActionCommandTests.Cancellation.cs
+++ b/tests/BB84.Notifications.Tests/Commands/AsyncActionCommandTests.Cancellation.cs
@@ -1,0 +1,170 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.Notifications.Commands;
+
+namespace BB84.Notifications.Tests.Commands;
+
+public sealed partial class AsyncActionCommandTests
+{
+  [TestMethod]
+  public async Task ExecuteAsyncWithCancellableDelegatePassesToken()
+  {
+    CancellationToken captured = CancellationToken.None;
+    AsyncActionCommand command = new(async ct =>
+    {
+      captured = ct;
+      await Task.CompletedTask;
+    });
+
+    await command.ExecuteAsync();
+
+    Assert.IsFalse(captured.IsCancellationRequested);
+  }
+
+  [TestMethod]
+  public async Task ExecuteAsyncWithExternalTokenPassesLinkedToken()
+  {
+    using CancellationTokenSource cts = new();
+    bool wasCancelled = false;
+
+    AsyncActionCommand command = new(async ct =>
+    {
+      await Task.Delay(500, ct);
+      wasCancelled = ct.IsCancellationRequested;
+    });
+
+    cts.CancelAfter(50);
+
+    try
+    {
+      await command.ExecuteAsync(cts.Token);
+    }
+    catch (OperationCanceledException) { }
+
+    Assert.IsFalse(wasCancelled); // OperationCanceledException thrown before assignment
+  }
+
+  [TestMethod]
+  public async Task CancelStopsExecution()
+  {
+    TaskCompletionSource<bool> started = new();
+    bool wasCancelled = false;
+    AsyncActionCommand command = new(async ct =>
+    {
+      started.SetResult(true);
+      try { await Task.Delay(5000, ct); }
+      catch (OperationCanceledException) { wasCancelled = true; throw; }
+    });
+
+    Task execution = command.ExecuteAsync();
+    await started.Task;
+
+    command.Cancel();
+
+    try { await execution; } catch (OperationCanceledException) { }
+
+    Assert.IsTrue(wasCancelled);
+  }
+
+  [TestMethod]
+  public async Task CancelCommandExecuteCancelsRunningOperation()
+  {
+    TaskCompletionSource<bool> started = new();
+    bool wasCancelled = false;
+    AsyncActionCommand command = new(async ct =>
+    {
+      started.SetResult(true);
+      try { await Task.Delay(5000, ct); }
+      catch (OperationCanceledException) { wasCancelled = true; throw; }
+    });
+
+    Task execution = command.ExecuteAsync();
+    await started.Task;
+
+    command.CancelCommand.Execute();
+
+    try { await execution; } catch (OperationCanceledException) { }
+
+    Assert.IsTrue(wasCancelled);
+  }
+
+  [TestMethod]
+  public async Task CanExecuteIsFalseWhileExecuting()
+  {
+    TaskCompletionSource<bool> started = new();
+    TaskCompletionSource<bool> release = new();
+    AsyncActionCommand command = new(async ct =>
+    {
+      started.SetResult(true);
+      await release.Task;
+    });
+
+    Task execution = command.ExecuteAsync();
+    await started.Task;
+
+    Assert.IsFalse(command.CanExecute());
+
+    release.SetResult(true);
+    await execution;
+  }
+
+  [TestMethod]
+  public async Task ExecuteAsyncWithCancellableDelegateGenericPassesToken()
+  {
+    CancellationToken captured = CancellationToken.None;
+    AsyncActionCommand<int> command = new(async (p, ct) =>
+    {
+      captured = ct;
+      await Task.CompletedTask;
+    });
+
+    await command.ExecuteAsync(42);
+
+    Assert.IsFalse(captured.IsCancellationRequested);
+  }
+
+  [TestMethod]
+  public async Task CancelGenericStopsExecution()
+  {
+    TaskCompletionSource<bool> started = new();
+    bool wasCancelled = false;
+    AsyncActionCommand<int> command = new(async (p, ct) =>
+    {
+      started.SetResult(true);
+      try { await Task.Delay(5000, ct); }
+      catch (OperationCanceledException) { wasCancelled = true; throw; }
+    });
+
+    Task execution = command.ExecuteAsync(1);
+    await started.Task;
+
+    command.Cancel();
+
+    try { await execution; } catch (OperationCanceledException) { }
+
+    Assert.IsTrue(wasCancelled);
+  }
+
+  [TestMethod]
+  public async Task CanExecuteIsFalseWhileExecutingGeneric()
+  {
+    TaskCompletionSource<bool> started = new();
+    TaskCompletionSource<bool> release = new();
+    AsyncActionCommand<int> command = new(async (p, ct) =>
+    {
+      started.SetResult(true);
+      await release.Task;
+    });
+
+    Task execution = command.ExecuteAsync(1);
+    await started.Task;
+
+    Assert.IsFalse(command.CanExecute(1));
+
+    release.SetResult(true);
+    await execution;
+  }
+}


### PR DESCRIPTION
**Changes:**

- Introduce `Cancel()`, `CancelCommand`, and `IsCancellationRequested` to `AsyncActionCommand` and `AsyncActionCommand<T>`.
- Support `CancellationToken` in constructors and `ExecuteAsync` methods.
- Update interfaces to expose cancellation features.
- Add unit tests for cancellation and execution state.
- Updated `README.md` with cancellable command usage examples.

closes #193 