### PR TITLE
fix(validation): raise `ErrorsChanged` for the affected property

### DIFF
--- a/src/BB84.Notifications/Interfaces/IValidatableObject.cs
+++ b/src/BB84.Notifications/Interfaces/IValidatableObject.cs
@@ -21,5 +21,21 @@ public interface IValidatableObject : INotifyPropertyChanged, INotifyPropertyCha
   /// <summary>
   /// Gets a value indicating whether the current state is valid.
   /// </summary>
+  /// <remarks>
+  /// This is a pure read over the errors recorded so far; it does not trigger validation.
+  /// Call <see cref="Validate"/> to (re-)evaluate the object before relying on this value.
+  /// </remarks>
   bool IsValid { get; }
+
+  /// <summary>
+  /// Validates the whole object and records the resulting validation errors.
+  /// </summary>
+  /// <remarks>
+  /// Any previously recorded errors are discarded, and <see cref="INotifyDataErrorInfo.ErrorsChanged"/>
+  /// is raised for every property whose errors were added or removed.
+  /// </remarks>
+  /// <returns>
+  /// <see langword="true"/> if the object passes validation; otherwise, <see langword="false"/>.
+  /// </returns>
+  bool Validate();
 }

--- a/src/BB84.Notifications/ValidatableObject.cs
+++ b/src/BB84.Notifications/ValidatableObject.cs
@@ -27,7 +27,7 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   public bool HasErrors => _errors.Count > 0;
 
   /// <inheritdoc/>
-  public bool IsValid => Validate();
+  public bool IsValid => _errors.Count is 0;
 
   /// <inheritdoc/>
   public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
@@ -105,34 +105,32 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   protected void RaiseErrorsChanged([CallerMemberName] string propertyName = "")
     => ErrorsChanged?.Invoke(this, new(propertyName));
 
-  /// <summary>
-  /// Validates the current object based on its data annotations.
-  /// </summary>
+  /// <inheritdoc/>
   /// <remarks>
   /// This method checks the object's properties and fields against the validation attributes
-  /// defined in its class. If validation fails, the validation errors are stored for further
-  /// inspection.
+  /// defined in its class. Every previously recorded error is discarded first, so an object
+  /// that now passes validation no longer reports errors from an earlier run.
   /// </remarks>
-  /// <returns>
-  /// <see langword="true"/> if the object passes validation; otherwise, <see langword="false"/>.
-  /// </returns>
-  protected virtual bool Validate()
+  public virtual bool Validate()
   {
     ValidationContext context = new(this);
     List<ValidationResult> results = [];
 
     bool isValid = Validator.TryValidateObject(this, context, results, true);
 
-    if (isValid)
-      return isValid;
-
+    string[] previousProperties = [.. _errors.Keys];
     _errors.Clear();
 
     foreach (ValidationResult result in results)
     {
       foreach (string propertyName in result.MemberNames)
-        AddError(propertyName, result.ErrorMessage);
+        AddErrorCore(propertyName, result.ErrorMessage);
     }
+
+    // Notify once per property that gained or lost errors, rather than once per
+    // individual message, so subscribers are not told about the same property twice.
+    foreach (string propertyName in previousProperties.Union(_errors.Keys))
+      RaiseErrorsChanged(propertyName);
 
     return isValid;
   }
@@ -156,7 +154,7 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
 
     ClearErrors(propertyName);
 
-    if (Validator.TryValidateProperty(value, context, results).Equals(false))
+    if (!Validator.TryValidateProperty(value, context, results))
     {
       foreach (ValidationResult result in results)
         AddError(propertyName, result.ErrorMessage);
@@ -180,13 +178,35 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   /// </param>
   protected void AddError(string propertyName, string? errorMessage)
   {
-    if (_errors.ContainsKey(propertyName).Equals(false))
-      _errors.Add(propertyName, []);
-
-    if (_errors[propertyName].Contains(errorMessage).Equals(false))
-      _errors[propertyName].Add(errorMessage);
-
+    AddErrorCore(propertyName, errorMessage);
     RaiseErrorsChanged(propertyName);
+  }
+
+  /// <summary>
+  /// Records an error message for a property without raising <see cref="ErrorsChanged"/>.
+  /// </summary>
+  /// <remarks>
+  /// Used by <see cref="Validate()"/>, which collects errors for many properties at once and
+  /// raises a single notification per affected property afterwards.
+  /// </remarks>
+  /// <param name="propertyName">
+  /// The name of the property for which the error is being recorded. Cannot be null or empty.
+  /// </param>
+  /// <param name="errorMessage">
+  /// The error message to associate with the property. Can be null, in which case no message is added.
+  /// </param>
+  private void AddErrorCore(string propertyName, string? errorMessage)
+  {
+    // The null check is redundant on annotated frameworks but keeps flow analysis
+    // happy on netstandard2.0, where TryGetValue carries no nullable annotations.
+    if (!_errors.TryGetValue(propertyName, out List<string?>? errorMessages) || errorMessages is null)
+    {
+      errorMessages = [];
+      _errors.Add(propertyName, errorMessages);
+    }
+
+    if (!errorMessages.Contains(errorMessage))
+      errorMessages.Add(errorMessage);
   }
 
   /// <summary>
@@ -202,6 +222,6 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   private void ClearErrors(string propertyName)
   {
     if (_errors.Remove(propertyName))
-      RaiseErrorsChanged();
+      RaiseErrorsChanged(propertyName);
   }
 }

--- a/tests/BB84.Notifications.Tests/ValidatableObjectTests.ErrorsChanged.cs
+++ b/tests/BB84.Notifications.Tests/ValidatableObjectTests.ErrorsChanged.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2023 Robert Peter Meyer
+// Copyright: 2023 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -10,14 +10,31 @@ public sealed partial class ValidatableObjectTests
   [TestMethod]
   public void ErrorsChanged()
   {
-    bool changed = false;
+    List<string?> changedProperties = [];
     TestClass tc = new();
-    tc.ErrorsChanged += (s, e) => changed = true;
+    tc.ErrorsChanged += (s, e) => changedProperties.Add(e.PropertyName);
 
     tc.Id = -12;
     tc.Id = 12;
 
     Assert.IsFalse(tc.HasErrors);
-    Assert.IsTrue(changed);
+    Assert.IsTrue(changedProperties.Count > 0);
+  }
+
+  [TestMethod]
+  public void ErrorsChangedReportsTheAffectedProperty()
+  {
+    List<string?> changedProperties = [];
+    TestClass tc = new();
+    tc.ErrorsChanged += (s, e) => changedProperties.Add(e.PropertyName);
+
+    // Recording the error notifies for Id, and clearing it again must notify
+    // for Id as well - not for the name of the member that did the clearing.
+    tc.Id = -12;
+    tc.Id = 12;
+
+    CollectionAssert.AreEqual(
+      new string?[] { nameof(TestClass.Id), nameof(TestClass.Id) },
+      changedProperties);
   }
 }

--- a/tests/BB84.Notifications.Tests/ValidatableObjectTests.Validate.cs
+++ b/tests/BB84.Notifications.Tests/ValidatableObjectTests.Validate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2023 Robert Peter Meyer
+// Copyright: 2023 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -12,9 +12,11 @@ public sealed partial class ValidatableObjectTests
   {
     TestClass tc = new(-23, "J", "D", "faksjdf;lkajsdf;lkasjdfl;kajsd;lfkjas;dfjkproituwerpu");
 
-    bool isValid = tc.IsValid;
+    bool isValid = tc.Validate();
 
     Assert.IsFalse(isValid);
+    Assert.IsFalse(tc.IsValid);
+    Assert.IsTrue(tc.HasErrors);
   }
 
   [TestMethod]
@@ -22,8 +24,42 @@ public sealed partial class ValidatableObjectTests
   {
     TestClass tc = new(1, "John", "Doe", "Jimmy");
 
-    bool isValid = tc.IsValid;
+    bool isValid = tc.Validate();
 
     Assert.IsTrue(isValid);
+    Assert.IsTrue(tc.IsValid);
+    Assert.IsFalse(tc.HasErrors);
+  }
+
+  [TestMethod]
+  public void IsValidDoesNotTriggerValidation()
+  {
+    TestClass tc = new(-23, "J", "D");
+
+    // Nothing has been validated yet, so no errors are recorded.
+    Assert.IsTrue(tc.IsValid);
+    Assert.IsFalse(tc.HasErrors);
+
+    Assert.IsFalse(tc.Validate());
+    Assert.IsFalse(tc.IsValid);
+  }
+
+  [TestMethod]
+  public void ValidateClearsStaleErrors()
+  {
+    TestClass tc = new(-23, "John", "Doe");
+
+    Assert.IsFalse(tc.Validate());
+    Assert.IsTrue(tc.HasErrors);
+
+    tc.SetIdWithoutValidation(1);
+
+    List<string?> changedProperties = [];
+    tc.ErrorsChanged += (s, e) => changedProperties.Add(e.PropertyName);
+
+    Assert.IsTrue(tc.Validate());
+    Assert.IsFalse(tc.HasErrors);
+    Assert.IsFalse(tc.GetErrors(nameof(TestClass.Id)).GetEnumerator().MoveNext());
+    CollectionAssert.Contains(changedProperties, nameof(TestClass.Id));
   }
 }

--- a/tests/BB84.Notifications.Tests/ValidatableObjectTests.cs
+++ b/tests/BB84.Notifications.Tests/ValidatableObjectTests.cs
@@ -47,5 +47,13 @@ public sealed partial class ValidatableObjectTests
       get => _lastName;
       set => SetPropertyAndValidate(ref _lastName, value);
     }
+
+    /// <summary>
+    /// Assigns <see cref="Id"/> through the non-validating <c>SetProperty</c> path, so the
+    /// recorded errors are left untouched and object-level validation can be observed
+    /// clearing them on its own.
+    /// </summary>
+    public void SetIdWithoutValidation(int value)
+      => SetProperty(ref _id, value);
   }
 }


### PR DESCRIPTION
**Changes:**

`ClearErrors` passed no argument to `RaiseErrorsChanged`, so the `[CallerMemberName]` default reported "ClearErrors" instead of the property whose errors were removed. A bound UI was never told the property became valid, so the error adornment never cleared.

Object-level `Validate()` also returned before clearing `_errors` on the valid path, so an object that started failing and later passed kept reporting `HasErrors == true` and served the old messages. It now clears on both paths and raises `ErrorsChanged` once per property that gained or lost errors, rather than once per message.

`IsValid` is now a pure read over the recorded errors and `Validate()` is public and part of `IValidatableObject`. Reading `IsValid` no longer triggers validation, so a never-validated object reports true.

**BREAKING CHANGE:**

`IsValid` no longer performs validation as a side effect of being read; call `Validate()` first.

closes #204 