### PR TITLE
refactor(properties): extract `NotifiablePropertyBase<T>`

### DIFF
--- a/src/BB84.Notifications/NotifiableProperty.cs
+++ b/src/BB84.Notifications/NotifiableProperty.cs
@@ -1,13 +1,8 @@
-﻿// Copyright: 2023 Robert Peter Meyer
+// Copyright: 2023 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-using System.ComponentModel;
-
-using BB84.Notifications.Components;
-using BB84.Notifications.Interfaces;
-
 namespace BB84.Notifications;
 
 /// <summary>
@@ -15,15 +10,19 @@ namespace BB84.Notifications;
 /// </summary>
 /// <remarks>
 /// The <see cref="NotifiableProperty{T}"/> class provides functionality for tracking changes
-/// to a property value. It raises <see cref="PropertyChanging"/> and <see cref="PropertyChanged"/>
-/// events when the value changes, allowing consumers to react to these changes.
+/// to a property value. It raises <see cref="NotifiablePropertyBase{T}.PropertyChanging"/> and
+/// <see cref="NotifiablePropertyBase{T}.PropertyChanged"/> events when the value changes,
+/// allowing consumers to react to these changes.
 /// </remarks>
 /// <typeparam name="T">The type of the property's value.</typeparam>
-/// <param name="value">The initial value of the property.</param>
-public sealed class NotifiableProperty<T>(T value) : INotifiableProperty<T>
+public sealed class NotifiableProperty<T> : NotifiablePropertyBase<T>
 {
-  private readonly IEqualityComparer<T> _comparer = EqualityComparer<T>.Default;
-  private T _value = value;
+  /// <summary>
+  /// Initializes a new instance of the <see cref="NotifiableProperty{T}"/> class.
+  /// </summary>
+  /// <param name="value">The initial value of the property.</param>
+  public NotifiableProperty(T value) : base(value)
+  { }
 
   /// <summary>
   /// Initializes a new instance of the <see cref="NotifiableProperty{T}"/> class with an initial
@@ -31,49 +30,8 @@ public sealed class NotifiableProperty<T>(T value) : INotifiableProperty<T>
   /// </summary>
   /// <param name="value">The initial value of the property.</param>
   /// <param name="comparer">The equality comparer used to determine whether the value has changed.</param>
-  public NotifiableProperty(T value, IEqualityComparer<T> comparer) : this(value)
-    => _comparer = comparer;
-
-  /// <inheritdoc/>
-  public bool IsDefault => EqualityComparer<T>.Default.Equals(_value, default!);
-
-  /// <inheritdoc/>
-  public bool IsNull => _value is null;
-
-  /// <inheritdoc/>
-  public T Value
-  {
-    get => _value;
-    set => SetProperty(ref _value, value);
-  }
-
-  /// <inheritdoc/>
-  public event PropertyChangedEventHandler? PropertyChanged;
-
-  /// <inheritdoc/>
-  public event PropertyChangingEventHandler? PropertyChanging;
-
-  /// <summary>
-  /// Updates the specified field with a new value and raises property change
-  /// notifications if the value changes.
-  /// </summary>
-  /// <remarks>
-  /// This method compares the current value of the field with the new value using the default
-  /// equality comparer. If the values are not equal, it raises the <see cref="PropertyChanging"/>
-  /// event with the old value, updates the field, and then raises the <see cref="PropertyChanged"/>
-  /// event with the new value.
-  /// </remarks> 
-  /// <param name="fieldValue">A reference to the backing field of the property.</param>
-  /// <param name="newValue">The new value to assign to the property.</param>
-  private void SetProperty(ref T fieldValue, T newValue)
-  {
-    if (!_comparer.Equals(fieldValue, newValue))
-    {
-      PropertyChanging?.Invoke(this, new PropertyChangingEventArgs<T>(fieldValue));
-      fieldValue = newValue;
-      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs<T>(newValue));
-    }
-  }
+  public NotifiableProperty(T value, IEqualityComparer<T> comparer) : base(value, comparer)
+  { }
 
   /// <summary>
   /// Implicitly converts a value of type <typeparamref name="T"/> to a <see cref="NotifiableProperty{T}"/>.
@@ -87,7 +45,7 @@ public sealed class NotifiableProperty<T>(T value) : INotifiableProperty<T>
   /// </summary>
   /// <remarks>
   /// This operator allows a <see cref="NotifiableProperty{T}"/> to be used directly as its underlying
-  /// value without explicitly accessing the <see cref="NotifiableProperty{T}.Value"/> property.
+  /// value without explicitly accessing the <see cref="NotifiablePropertyBase{T}.Value"/> property.
   /// </remarks>
   /// <param name="property">The <see cref="NotifiableProperty{T}"/> instance to convert.</param>
   public static implicit operator T(NotifiableProperty<T> property)

--- a/src/BB84.Notifications/NotifiablePropertyBase.cs
+++ b/src/BB84.Notifications/NotifiablePropertyBase.cs
@@ -1,0 +1,138 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.ComponentModel;
+
+using BB84.Notifications.Components;
+using BB84.Notifications.Interfaces;
+
+namespace BB84.Notifications;
+
+/// <summary>
+/// Provides the shared infrastructure for properties that raise change notifications.
+/// </summary>
+/// <remarks>
+/// This class owns the value, the equality comparer used to detect changes, and both
+/// notification events. Derived types add their own behaviour by overriding
+/// <see cref="OnValueChanging(T)"/>, which runs after the value is known to have changed
+/// but before any notification is raised and can veto the assignment entirely.
+/// </remarks>
+/// <typeparam name="T">The type of the property's value.</typeparam>
+public abstract class NotifiablePropertyBase<T> : INotifiableProperty<T>
+{
+  private readonly IEqualityComparer<T> _comparer;
+  private T _value;
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="NotifiablePropertyBase{T}"/> class.
+  /// </summary>
+  /// <param name="value">The initial value of the property.</param>
+  /// <param name="comparer">
+  /// The equality comparer used to determine whether the value has changed.
+  /// When <see langword="null"/>, <see cref="EqualityComparer{T}.Default"/> is used.
+  /// </param>
+  protected NotifiablePropertyBase(T value, IEqualityComparer<T>? comparer = null)
+  {
+    _comparer = comparer ?? EqualityComparer<T>.Default;
+    _value = value;
+  }
+
+  /// <inheritdoc/>
+  /// <remarks>
+  /// This check always uses <see cref="EqualityComparer{T}.Default"/>, independent of the
+  /// comparer supplied for change detection.
+  /// </remarks>
+  public bool IsDefault => EqualityComparer<T>.Default.Equals(_value, default!);
+
+  /// <inheritdoc/>
+  public bool IsNull => _value is null;
+
+  /// <inheritdoc/>
+  public T Value
+  {
+    get => _value;
+    set => SetValue(value);
+  }
+
+  /// <inheritdoc/>
+  public event PropertyChangedEventHandler? PropertyChanged;
+
+  /// <inheritdoc/>
+  public event PropertyChangingEventHandler? PropertyChanging;
+
+  /// <summary>
+  /// Assigns a new value and raises the change notifications when it differs from the current one.
+  /// </summary>
+  /// <remarks>
+  /// The value is compared using the comparer supplied at construction. When it has changed,
+  /// <see cref="OnValueChanging(T)"/> is consulted before anything is assigned or raised.
+  /// </remarks>
+  /// <param name="newValue">The new value to assign.</param>
+  /// <returns>
+  /// <see langword="true"/> if the value was assigned and notifications were raised;
+  /// otherwise, <see langword="false"/>.
+  /// </returns>
+  protected bool SetValue(T newValue)
+  {
+    if (_comparer.Equals(_value, newValue))
+      return false;
+
+    if (!OnValueChanging(newValue))
+      return false;
+
+    RaiseAndAssign(newValue);
+    return true;
+  }
+
+  /// <summary>
+  /// Assigns a new value and raises the change notifications without consulting
+  /// <see cref="OnValueChanging(T)"/>.
+  /// </summary>
+  /// <remarks>
+  /// Use this when the derived type is restoring a value it already owns - navigating an
+  /// existing history, for example - so that the side effects of
+  /// <see cref="OnValueChanging(T)"/> are not applied a second time.
+  /// </remarks>
+  /// <param name="newValue">The new value to assign.</param>
+  /// <returns>
+  /// <see langword="true"/> if the value was assigned and notifications were raised;
+  /// otherwise, <see langword="false"/>.
+  /// </returns>
+  protected bool ForceValue(T newValue)
+  {
+    if (_comparer.Equals(_value, newValue))
+      return false;
+
+    RaiseAndAssign(newValue);
+    return true;
+  }
+
+  /// <summary>
+  /// Called when the value has been found to differ, before it is assigned.
+  /// </summary>
+  /// <remarks>
+  /// Derived types override this to attach behaviour to a change, and may return
+  /// <see langword="false"/> to abort the assignment so that no notification is raised.
+  /// The default implementation accepts every change.
+  /// </remarks>
+  /// <param name="newValue">The value that is about to be assigned.</param>
+  /// <returns>
+  /// <see langword="true"/> to proceed with the assignment; <see langword="false"/> to abort it.
+  /// </returns>
+  protected virtual bool OnValueChanging(T newValue)
+    => true;
+
+  /// <summary>
+  /// Raises <see cref="PropertyChanging"/> with the outgoing value, assigns the new value and
+  /// raises <see cref="PropertyChanged"/> with it.
+  /// </summary>
+  /// <param name="newValue">The new value to assign.</param>
+  private void RaiseAndAssign(T newValue)
+  {
+    PropertyChanging?.Invoke(this, new PropertyChangingEventArgs<T>(_value));
+    _value = newValue;
+    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs<T>(newValue));
+  }
+}

--- a/src/BB84.Notifications/ReversibleProperty.cs
+++ b/src/BB84.Notifications/ReversibleProperty.cs
@@ -1,11 +1,8 @@
-﻿// Copyright: 2023 Robert Peter Meyer
+// Copyright: 2023 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
-using System.ComponentModel;
-
-using BB84.Notifications.Components;
 using BB84.Notifications.Interfaces;
 
 namespace BB84.Notifications;
@@ -22,13 +19,12 @@ namespace BB84.Notifications;
 /// supplied at construction time (default: <see cref="OverflowStrategy.EvictOldest"/>).
 /// </remarks>
 /// <typeparam name="T">The type of the property's value.</typeparam>
-public sealed class ReversibleProperty<T> : INotifiableProperty<T>, IReversibleProperty<T>
+public sealed class ReversibleProperty<T> : NotifiablePropertyBase<T>, IReversibleProperty<T>
 {
   private const int DefaultSize = 10;
   private readonly int _size;
   private readonly OverflowStrategy _overflow;
   private readonly List<T> _values;
-  private T _value;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="ReversibleProperty{T}"/> class
@@ -44,11 +40,32 @@ public sealed class ReversibleProperty<T> : INotifiableProperty<T>, IReversibleP
   /// Defaults to <see cref="OverflowStrategy.EvictOldest"/>.
   /// </param>
   public ReversibleProperty(T value, int size = DefaultSize, OverflowStrategy overflow = OverflowStrategy.EvictOldest)
+    : this(value, null, size, overflow)
+  { }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="ReversibleProperty{T}"/> class with the
+  /// specified initial value, equality comparer, history size, and overflow strategy.
+  /// </summary>
+  /// <param name="value">The initial value of the property.</param>
+  /// <param name="comparer">
+  /// The equality comparer used to determine whether the value has changed.
+  /// When <see langword="null"/>, <see cref="EqualityComparer{T}.Default"/> is used.
+  /// </param>
+  /// <param name="size">
+  /// The maximum number of values to retain in the history.
+  /// Defaults to 10 and must be a positive integer.
+  /// </param>
+  /// <param name="overflow">
+  /// The strategy to apply when a new value is added and the history is already full.
+  /// Defaults to <see cref="OverflowStrategy.EvictOldest"/>.
+  /// </param>
+  public ReversibleProperty(T value, IEqualityComparer<T>? comparer, int size = DefaultSize, OverflowStrategy overflow = OverflowStrategy.EvictOldest)
+    : base(value, comparer)
   {
     _size = size;
     _overflow = overflow;
     _values = new(size);
-    _value = value;
     _ = TryAddValue(value);
   }
 
@@ -59,29 +76,10 @@ public sealed class ReversibleProperty<T> : INotifiableProperty<T>, IReversibleP
   public int Index { get; private set; }
 
   /// <inheritdoc/>
-  public bool IsDefault => EqualityComparer<T>.Default.Equals(_value, default!);
-
-  /// <inheritdoc/>
-  public bool IsNull => _value is null;
-
-  /// <inheritdoc/>
   public bool HasNextValue => _values.Count > Index + 1;
 
   /// <inheritdoc/>
   public bool HasPreviousValue => Index > 0;
-
-  /// <inheritdoc/>
-  public T Value
-  {
-    get => _value;
-    set => SetProperty(ref _value, value);
-  }
-
-  /// <inheritdoc/>
-  public event PropertyChangedEventHandler? PropertyChanged;
-
-  /// <inheritdoc/>
-  public event PropertyChangingEventHandler? PropertyChanging;
 
   /// <inheritdoc/>
   public void NextValue()
@@ -90,8 +88,7 @@ public sealed class ReversibleProperty<T> : INotifiableProperty<T>, IReversibleP
       return;
 
     Index++;
-    T value = _values[Index];
-    SetProperty(ref _value, value, false);
+    ForceValue(_values[Index]);
   }
 
   /// <inheritdoc/>
@@ -101,21 +98,35 @@ public sealed class ReversibleProperty<T> : INotifiableProperty<T>, IReversibleP
       return;
 
     Index--;
-    T value = _values[Index];
-    SetProperty(ref _value, value, false);
+    ForceValue(_values[Index]);
   }
 
   /// <inheritdoc/>
   public void Clear()
   {
     _values.Clear();
-    _values.Add(_value);
+    _values.Add(Value);
     Index = 0;
   }
 
   /// <inheritdoc/>
   public IReadOnlyList<T> Snapshot()
     => _values.AsReadOnly();
+
+  /// <summary>
+  /// Records the incoming value in the history before it is assigned.
+  /// </summary>
+  /// <remarks>
+  /// Returning <see langword="false"/> aborts the assignment, which is how
+  /// <see cref="OverflowStrategy.EvictNewest"/> rejects a value once the buffer is full.
+  /// </remarks>
+  /// <param name="newValue">The value that is about to be assigned.</param>
+  /// <returns>
+  /// <see langword="true"/> when the value was recorded and may be assigned;
+  /// otherwise, <see langword="false"/>.
+  /// </returns>
+  protected override bool OnValueChanging(T newValue)
+    => TryAddValue(newValue);
 
   /// <summary>
   /// Implicitly converts a value of type <typeparamref name="T"/> to a
@@ -136,28 +147,6 @@ public sealed class ReversibleProperty<T> : INotifiableProperty<T>, IReversibleP
   /// </param>
   public static implicit operator T(ReversibleProperty<T> property)
     => property.Value;
-
-  /// <summary>
-  /// Updates the value of a property and raises the appropriate change notifications.
-  /// </summary>
-  /// <param name="oldValue">A reference to the current value. Updated to <paramref name="newValue"/> when not equal.</param>
-  /// <param name="newValue">The new value to set for the property.</param>
-  /// <param name="addToHistory">
-  /// <see langword="true"/> to record the new value in the history; <see langword="false"/> when
-  /// navigating the existing history (NextValue/PreviousValue).
-  /// </param>
-  private void SetProperty(ref T oldValue, T newValue, bool addToHistory = true)
-  {
-    if (!EqualityComparer<T>.Default.Equals(oldValue, newValue))
-    {
-      if (addToHistory && !TryAddValue(newValue))
-        return;
-
-      PropertyChanging?.Invoke(this, new PropertyChangingEventArgs<T>(oldValue));
-      oldValue = newValue;
-      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs<T>(newValue));
-    }
-  }
 
   /// <summary>
   /// Attempts to add a value to the history, respecting the configured <see cref="OverflowStrategy"/>.

--- a/tests/BB84.Notifications.Tests/ReversiblePropertyTests.Comparer.cs
+++ b/tests/BB84.Notifications.Tests/ReversiblePropertyTests.Comparer.cs
@@ -1,0 +1,74 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Notifications.Tests;
+
+public sealed partial class ReversiblePropertyTests
+{
+  [TestMethod]
+  [TestCategory("Comparer")]
+  public void SetPropertyWithComparerDoesNotRaiseWhenEqual()
+  {
+    bool raised = false;
+    ReversibleProperty<string> property = new("hello", StringComparer.OrdinalIgnoreCase);
+    property.PropertyChanged += (sender, e) => raised = true;
+
+    property.Value = "HELLO";
+
+    Assert.IsFalse(raised);
+  }
+
+  [TestMethod]
+  [TestCategory("Comparer")]
+  public void SetPropertyWithComparerRaisesWhenNotEqual()
+  {
+    bool raised = false;
+    ReversibleProperty<string> property = new("hello", StringComparer.OrdinalIgnoreCase);
+    property.PropertyChanged += (sender, e) => raised = true;
+
+    property.Value = "world";
+
+    Assert.IsTrue(raised);
+    Assert.AreEqual("world", property.Value);
+  }
+
+  [TestMethod]
+  [TestCategory("Comparer")]
+  public void SetPropertyWithComparerChangingRaisesWhenNotEqual()
+  {
+    bool raised = false;
+    ReversibleProperty<string> property = new("hello", StringComparer.OrdinalIgnoreCase);
+    property.PropertyChanging += (sender, e) => raised = true;
+
+    property.Value = "world";
+
+    Assert.IsTrue(raised);
+  }
+
+  [TestMethod]
+  [TestCategory("Comparer")]
+  public void SetPropertyWithComparerDoesNotRecordHistoryWhenEqual()
+  {
+    ReversibleProperty<string> property = new("hello", StringComparer.OrdinalIgnoreCase);
+
+    property.Value = "HELLO";
+
+    Assert.AreEqual(1, property.Count);
+  }
+
+  [TestMethod]
+  [TestCategory("Comparer")]
+  public void ComparerIsHonouredAlongsideSizeAndOverflow()
+  {
+    ReversibleProperty<string> property = new("a", StringComparer.OrdinalIgnoreCase, 2, OverflowStrategy.EvictNewest);
+    property.Value = "b";
+
+    // Buffer is full, so EvictNewest must reject the assignment.
+    property.Value = "c";
+
+    Assert.AreEqual(2, property.Count);
+    Assert.AreEqual("b", property.Value);
+  }
+}

--- a/tests/BB84.Notifications.Tests/ReversiblePropertyTests.Navigation.cs
+++ b/tests/BB84.Notifications.Tests/ReversiblePropertyTests.Navigation.cs
@@ -1,0 +1,65 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Notifications.Tests;
+
+public sealed partial class ReversiblePropertyTests
+{
+  [TestMethod]
+  [TestCategory("Method")]
+  public void NavigationDoesNotRecordHistory()
+  {
+    ReversibleProperty<int> property = new(0);
+    property.Value = 1;
+    property.Value = 2;
+
+    int[] historyAfterAssignments = [.. property.Snapshot()];
+
+    property.PreviousValue();
+    property.PreviousValue();
+    property.NextValue();
+
+    // Navigating an existing history must neither append to it nor truncate the
+    // forward entries. Asserting on Count alone is not enough: re-recording a value
+    // that was just truncated can leave the length unchanged while corrupting the
+    // contents.
+    CollectionAssert.AreEqual(historyAfterAssignments, (System.Collections.ICollection)property.Snapshot());
+    Assert.AreEqual(1, property.Value);
+  }
+
+  [TestMethod]
+  [TestCategory("Method")]
+  public void NavigationRaisesNotifications()
+  {
+    List<int> changed = [];
+    ReversibleProperty<int> property = new(0);
+    property.Value = 1;
+    property.PropertyChanged += (sender, e) =>
+    {
+      if (e is Components.PropertyChangedEventArgs<int> typed)
+        changed.Add(typed.Value);
+    };
+
+    property.PreviousValue();
+    property.NextValue();
+
+    int[] expected = [0, 1];
+    CollectionAssert.AreEqual(expected, changed);
+  }
+
+  [TestMethod]
+  [TestCategory("Method")]
+  public void NavigationDoesNotTruncateForwardHistory()
+  {
+    ReversibleProperty<int> property = new(0);
+    property.Value = 1;
+    property.Value = 2;
+
+    property.PreviousValue();
+
+    Assert.IsTrue(property.HasNextValue);
+    Assert.AreEqual(3, property.Count);
+  }
+}


### PR DESCRIPTION
**Changes:**

`NotifiableProperty<T>` and `ReversibleProperty<T>` each hand-rolled the same infrastructure: the backing field, `IsDefault`, `IsNull`, `Value`, both notification events and a private `SetProperty`. `IsDefault`, `IsNull` and the event declarations were character-for-character identical.

The shared parts now live in `NotifiablePropertyBase<T>`. Derived types hook into the set pipeline by overriding `OnValueChanging`, which runs after the value is known to differ and can veto the assignment - that is how `EvictNewest` rejects a value once the history is full.

History navigation goes through `ForceValue` instead, bypassing the hook so that moving through existing entries does not re-record them.

The duplication had already caused a capability gap: `NotifiableProperty` accepted a custom `IEqualityComparer<T>` while `ReversibleProperty` hardcoded the default. `ReversibleProperty` now takes one too.

closes #206 