### PR TITLE
refactor(core): collapse the duplicated `SetProperty` comparer overloads

### DIFF
--- a/src/BB84.Notifications/NotifiableObject.cs
+++ b/src/BB84.Notifications/NotifiableObject.cs
@@ -36,10 +36,10 @@ public abstract class NotifiableObject : INotifiableObject
   /// Updates the specified field with a new value and raises property change notifications.
   /// </summary>
   /// <remarks>
-  /// This method compares the current value of the field with the new value using the default
-  /// equality comparer. If the values are not equal, it updates the field and raises property
-  /// change notifications. Use this method to implement property setters in classes that
-  /// support change tracking or data binding.
+  /// This method forwards to <see cref="SetProperty{T}(ref T, T, IEqualityComparer{T}, string)"/>
+  /// using <see cref="EqualityComparer{T}.Default"/>. If the values are not equal, it updates the
+  /// field and raises property change notifications. Use this method to implement property setters
+  /// in classes that support change tracking or data binding.
   /// </remarks>
   /// <typeparam name="T">The type of the property being updated.</typeparam>
   /// <param name="fieldValue">A reference to the backing field of the property.</param>
@@ -48,28 +48,21 @@ public abstract class NotifiableObject : INotifiableObject
   /// The name of the property being updated.
   /// This parameter is optional and automatically provided by the compiler if not explicitly specified.
   /// </param>
-  protected void SetProperty<T>(ref T fieldValue, T newValue, [CallerMemberName] string propertyName = "")
-  {
-    if (!EqualityComparer<T>.Default.Equals(fieldValue, newValue))
-    {
-      RaisePropertyChanging(propertyName, fieldValue);
-      RaiseChangingAttribute(propertyName);
-
-      fieldValue = newValue;
-
-      RaisePropertyChanged(propertyName, newValue);
-      RaiseChangedAttribute(propertyName);
-    }
-  }
+  /// <returns>
+  /// <see langword="true"/> if the value differed and the field was updated;
+  /// otherwise, <see langword="false"/>.
+  /// </returns>
+  protected bool SetProperty<T>(ref T fieldValue, T newValue, [CallerMemberName] string propertyName = "")
+    => SetProperty(ref fieldValue, newValue, EqualityComparer<T>.Default, propertyName);
 
   /// <summary>
   /// Updates the specified field with a new value using a custom equality comparer and raises
   /// property change notifications.
   /// </summary>
   /// <remarks>
-  /// This method behaves identically to <see cref="SetProperty{T}(ref T, T, string)"/> but uses
-  /// the supplied <paramref name="comparer"/> instead of <see cref="EqualityComparer{T}.Default"/>
-  /// to determine whether the value has actually changed.
+  /// This is the underlying implementation for both overloads; it uses the supplied
+  /// <paramref name="comparer"/> to determine whether the value has actually changed, and raises
+  /// the changing and changed notifications, including any attribute-driven dependent properties.
   /// </remarks>
   /// <typeparam name="T">The type of the property being updated.</typeparam>
   /// <param name="fieldValue">A reference to the backing field of the property.</param>
@@ -79,18 +72,24 @@ public abstract class NotifiableObject : INotifiableObject
   /// The name of the property being updated.
   /// This parameter is optional and automatically provided by the compiler if not explicitly specified.
   /// </param>
-  protected void SetProperty<T>(ref T fieldValue, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string propertyName = "")
+  /// <returns>
+  /// <see langword="true"/> if the value differed and the field was updated;
+  /// otherwise, <see langword="false"/>.
+  /// </returns>
+  protected bool SetProperty<T>(ref T fieldValue, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string propertyName = "")
   {
-    if (!comparer.Equals(fieldValue, newValue))
-    {
-      RaisePropertyChanging(propertyName, fieldValue);
-      RaiseChangingAttribute(propertyName);
+    if (comparer.Equals(fieldValue, newValue))
+      return false;
 
-      fieldValue = newValue;
+    RaisePropertyChanging(propertyName, fieldValue);
+    RaiseChangingAttribute(propertyName);
 
-      RaisePropertyChanged(propertyName, newValue);
-      RaiseChangedAttribute(propertyName);
-    }
+    fieldValue = newValue;
+
+    RaisePropertyChanged(propertyName, newValue);
+    RaiseChangedAttribute(propertyName);
+
+    return true;
   }
 
   /// <summary>

--- a/src/BB84.Notifications/ValidatableObject.cs
+++ b/src/BB84.Notifications/ValidatableObject.cs
@@ -48,8 +48,10 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   /// Sets the specified property to a new value and performs validation.
   /// </summary>
   /// <remarks>
-  /// This method updates the property value only if the new value differs from the current value.
-  /// After updating the property, it performs validation using the provided value and property name.
+  /// This method forwards to
+  /// <see cref="SetPropertyAndValidate{T}(ref T, T, IEqualityComparer{T}, string)"/> using
+  /// <see cref="EqualityComparer{T}.Default"/>. The property value is updated only if the new
+  /// value differs from the current one, and validation runs only when it did.
   /// </remarks>
   /// <typeparam name="T">The type of the property value.</typeparam>
   /// <param name="fieldValue">A reference to the backing field of the property.</param>
@@ -57,22 +59,20 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   /// <param name="propertyName">
   /// The name of the property being set. This parameter is optional and defaults to the caller's member name.
   /// </param>
-  protected void SetPropertyAndValidate<T>(ref T fieldValue, T newValue, [CallerMemberName] string propertyName = "")
-  {
-    if (!EqualityComparer<T>.Default.Equals(fieldValue, newValue))
-    {
-      SetProperty(ref fieldValue, newValue, propertyName);
-      Validate(newValue, propertyName);
-    }
-  }
+  /// <returns>
+  /// <see langword="true"/> if the value differed, the field was updated and validation ran;
+  /// otherwise, <see langword="false"/>.
+  /// </returns>
+  protected bool SetPropertyAndValidate<T>(ref T fieldValue, T newValue, [CallerMemberName] string propertyName = "")
+    => SetPropertyAndValidate(ref fieldValue, newValue, EqualityComparer<T>.Default, propertyName);
 
   /// <summary>
   /// Sets the specified property to a new value using a custom equality comparer and performs validation.
   /// </summary>
   /// <remarks>
-  /// This method behaves identically to <see cref="SetPropertyAndValidate{T}(ref T, T, string)"/> but
-  /// uses the supplied <paramref name="comparer"/> instead of <see cref="EqualityComparer{T}.Default"/>
-  /// to determine whether the value has actually changed.
+  /// This is the underlying implementation for both overloads. The comparison is delegated to
+  /// <see cref="NotifiableObject.SetProperty{T}(ref T, T, IEqualityComparer{T}, string)"/>, whose
+  /// result gates the validation pass, so <paramref name="comparer"/> is consulted exactly once.
   /// </remarks>
   /// <typeparam name="T">The type of the property value.</typeparam>
   /// <param name="fieldValue">A reference to the backing field of the property.</param>
@@ -81,13 +81,17 @@ public abstract class ValidatableObject : NotifiableObject, Interfaces.IValidata
   /// <param name="propertyName">
   /// The name of the property being set. This parameter is optional and defaults to the caller's member name.
   /// </param>
-  protected void SetPropertyAndValidate<T>(ref T fieldValue, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string propertyName = "")
+  /// <returns>
+  /// <see langword="true"/> if the value differed, the field was updated and validation ran;
+  /// otherwise, <see langword="false"/>.
+  /// </returns>
+  protected bool SetPropertyAndValidate<T>(ref T fieldValue, T newValue, IEqualityComparer<T> comparer, [CallerMemberName] string propertyName = "")
   {
-    if (!comparer.Equals(fieldValue, newValue))
-    {
-      SetProperty(ref fieldValue, newValue, comparer, propertyName);
-      Validate(newValue, propertyName);
-    }
+    if (!SetProperty(ref fieldValue, newValue, comparer, propertyName))
+      return false;
+
+    Validate(newValue, propertyName);
+    return true;
   }
 
   /// <summary>

--- a/tests/BB84.Notifications.Tests/NotifiableObjectTests.ReturnValue.cs
+++ b/tests/BB84.Notifications.Tests/NotifiableObjectTests.ReturnValue.cs
@@ -1,0 +1,73 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+namespace BB84.Notifications.Tests;
+
+public sealed partial class NotifiableObjectTests
+{
+  [TestMethod]
+  public void SetPropertyReturnsTrueWhenValueChanged()
+  {
+    TestClass testClass = new();
+
+    Assert.IsTrue(testClass.TrySetProperty(42));
+    Assert.AreEqual(42, testClass.Property);
+  }
+
+  [TestMethod]
+  public void SetPropertyReturnsFalseWhenValueUnchanged()
+  {
+    TestClass testClass = new();
+    testClass.TrySetProperty(42);
+
+    Assert.IsFalse(testClass.TrySetProperty(42));
+  }
+
+  [TestMethod]
+  public void SetPropertyWithComparerReturnsTrueWhenValueChanged()
+  {
+    TestClass testClass = new();
+
+    Assert.IsTrue(testClass.TrySetProperty(7, EqualityComparer<int>.Default));
+  }
+
+  [TestMethod]
+  public void SetPropertyWithComparerReturnsFalseWhenValueUnchanged()
+  {
+    TestClass testClass = new();
+    testClass.TrySetProperty(7, EqualityComparer<int>.Default);
+
+    Assert.IsFalse(testClass.TrySetProperty(7, EqualityComparer<int>.Default));
+  }
+
+  [TestMethod]
+  public void SetPropertyConsultsTheComparerExactlyOnce()
+  {
+    CountingComparer comparer = new();
+    TestClass testClass = new();
+
+    testClass.TrySetProperty(1, comparer);
+
+    Assert.AreEqual(1, comparer.EqualsCallCount);
+  }
+
+  /// <summary>
+  /// Counts how often the set pipeline compares values, so the collapsed overloads
+  /// cannot silently regress into comparing twice.
+  /// </summary>
+  private sealed class CountingComparer : IEqualityComparer<int>
+  {
+    public int EqualsCallCount { get; private set; }
+
+    public bool Equals(int x, int y)
+    {
+      EqualsCallCount++;
+      return x == y;
+    }
+
+    public int GetHashCode(int obj)
+      => obj.GetHashCode();
+  }
+}

--- a/tests/BB84.Notifications.Tests/NotifiableObjectTests.cs
+++ b/tests/BB84.Notifications.Tests/NotifiableObjectTests.cs
@@ -17,5 +17,17 @@ public sealed partial class NotifiableObjectTests
       get => _property;
       set => SetProperty(ref _property, value);
     }
+
+    /// <summary>
+    /// Surfaces the <c>SetProperty</c> return value, which a property setter cannot.
+    /// </summary>
+    public bool TrySetProperty(int value)
+      => SetProperty(ref _property, value, nameof(Property));
+
+    /// <summary>
+    /// Surfaces the return value of the comparer overload.
+    /// </summary>
+    public bool TrySetProperty(int value, IEqualityComparer<int> comparer)
+      => SetProperty(ref _property, value, comparer, nameof(Property));
   }
 }

--- a/tests/BB84.Notifications.Tests/ValidatableObjectTests.ReturnValue.cs
+++ b/tests/BB84.Notifications.Tests/ValidatableObjectTests.ReturnValue.cs
@@ -1,0 +1,96 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using System.ComponentModel.DataAnnotations;
+
+namespace BB84.Notifications.Tests;
+
+public sealed partial class ValidatableObjectTests
+{
+  [TestMethod]
+  public void SetPropertyAndValidateReturnsTrueWhenValueChanged()
+  {
+    TestClassWithCountingComparer tc = new(new CountingStringComparer());
+
+    Assert.IsTrue(tc.TrySetName("world"));
+    Assert.AreEqual("world", tc.Name);
+  }
+
+  [TestMethod]
+  public void SetPropertyAndValidateReturnsFalseWhenValueUnchanged()
+  {
+    TestClassWithCountingComparer tc = new(new CountingStringComparer());
+    tc.TrySetName("world");
+
+    Assert.IsFalse(tc.TrySetName("world"));
+  }
+
+  [TestMethod]
+  public void SetPropertyAndValidateConsultsTheComparerExactlyOnce()
+  {
+    CountingStringComparer comparer = new();
+    TestClassWithCountingComparer tc = new(comparer);
+
+    tc.Name = "world";
+
+    // Previously the value was compared once by SetPropertyAndValidate and again
+    // by the SetProperty it delegated to.
+    Assert.AreEqual(1, comparer.EqualsCallCount);
+  }
+
+  [TestMethod]
+  public void SetPropertyAndValidateSkipsValidationWhenValueUnchanged()
+  {
+    CountingStringComparer comparer = new();
+    TestClassWithCountingComparer tc = new(comparer);
+    tc.Name = new string('x', 51);
+
+    Assert.IsTrue(tc.HasErrors);
+
+    bool raised = false;
+    tc.ErrorsChanged += (s, e) => raised = true;
+
+    // Assigning the same invalid value again must not re-run validation.
+    tc.Name = new string('x', 51);
+
+    Assert.IsFalse(raised);
+  }
+
+  private sealed class TestClassWithCountingComparer(IEqualityComparer<string> comparer) : ValidatableObject
+  {
+    private string _name = string.Empty;
+
+    [Required, MaxLength(50)]
+    public string Name
+    {
+      get => _name;
+      set => SetPropertyAndValidate(ref _name, value, comparer);
+    }
+
+    /// <summary>
+    /// Surfaces the <c>SetPropertyAndValidate</c> return value, which a property setter cannot.
+    /// </summary>
+    public bool TrySetName(string value)
+      => SetPropertyAndValidate(ref _name, value, comparer, nameof(Name));
+  }
+
+  /// <summary>
+  /// Counts how often the set pipeline compares values, so the collapsed overloads
+  /// cannot silently regress into comparing twice.
+  /// </summary>
+  private sealed class CountingStringComparer : IEqualityComparer<string>
+  {
+    public int EqualsCallCount { get; private set; }
+
+    public bool Equals(string? x, string? y)
+    {
+      EqualsCallCount++;
+      return StringComparer.Ordinal.Equals(x, y);
+    }
+
+    public int GetHashCode(string obj)
+      => StringComparer.Ordinal.GetHashCode(obj);
+  }
+}


### PR DESCRIPTION
**Changes:**

`SetProperty` and `SetPropertyAndValidate` each existed twice with copy-pasted bodies differing only in `EqualityComparer<T>.Default` versus an injected comparer, so the notification sequence was written four times and a fix applied to three of them would have been silent.

The comparer overload is now the single implementation and the default overload forwards to it, passing `propertyName` explicitly so `[CallerMemberName]` does not re-resolve to the wrong member.

Both now return bool. `SetPropertyAndValidate` gates validation on that result instead of repeating the comparison, so a custom comparer is consulted once per set rather than twice.

**BREAKING CHANGE:**

`SetProperty` and `SetPropertyAndValidate` return bool instead of void. Source-compatible for callers that ignore the result, binary-breaking for existing compiled consumers.

closes #205 