### PR TITLE
fix(commands): return a stable `CancelCommand` instance

### DIFF
--- a/src/BB84.Notifications/Commands/AsyncActionCommand.cs
+++ b/src/BB84.Notifications/Commands/AsyncActionCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright: 2023 Robert Peter Meyer
+// Copyright: 2023 Robert Peter Meyer
 // License: MIT
 //
 // This source code is licensed under the MIT license found in the
@@ -12,21 +12,28 @@ namespace BB84.Notifications.Commands;
 /// Represents an asynchronous command that can be executed and queried for its ability to execute.
 /// </summary>
 /// <remarks>
-/// When a <c>Func&lt;CancellationToken, Task&gt;</c> delegate is supplied the command manages its own
-/// <see cref="CancellationTokenSource"/> internally. Call <see cref="Cancel"/> (or execute
-/// <see cref="CancelCommand"/>) to cancel a running operation.
+/// The command manages its own <see cref="CancellationTokenSource"/> internally. Call
+/// <see cref="AsyncActionCommandBase.Cancel"/> (or execute
+/// <see cref="AsyncActionCommandBase.CancelCommand"/>) to cancel a running operation.
 /// </remarks>
-/// <param name="execute">The task to execute (without cancellation token).</param>
-/// <param name="canExecute">The condition to execute.</param>
-/// <param name="action">The action to invoke if an exception occurs.</param>
-public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecute = null, Action<Exception>? action = null) : IAsyncActionCommand
+public sealed class AsyncActionCommand : AsyncActionCommandBase, IAsyncActionCommand
 {
-  private readonly Func<CancellationToken, Task> _execute = _ => execute();
-  private readonly Func<bool>? _canExecute = canExecute;
-  private readonly Action<Exception>? _action = action;
+  private readonly Func<CancellationToken, Task> _execute;
+  private readonly Func<bool>? _canExecute;
+  private readonly Action<Exception>? _action;
 
-  private bool _isExecuting;
-  private CancellationTokenSource? _cts;
+  /// <summary>
+  /// Initializes a new instance of <see cref="AsyncActionCommand"/>.
+  /// </summary>
+  /// <param name="execute">The task to execute (without cancellation token).</param>
+  /// <param name="canExecute">The condition to execute.</param>
+  /// <param name="action">The action to invoke if an exception occurs.</param>
+  public AsyncActionCommand(Func<Task> execute, Func<bool>? canExecute = null, Action<Exception>? action = null)
+  {
+    _execute = _ => execute();
+    _canExecute = canExecute;
+    _action = action;
+  }
 
   /// <summary>
   /// Initializes a new instance of <see cref="AsyncActionCommand"/> with a cancellable execute delegate.
@@ -35,30 +42,19 @@ public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecut
   /// <param name="canExecute">The condition to execute.</param>
   /// <param name="action">The action to invoke if an exception occurs.</param>
   public AsyncActionCommand(Func<CancellationToken, Task> execute, Func<bool>? canExecute = null, Action<Exception>? action = null)
-    : this(() => execute(CancellationToken.None), canExecute, action)
   {
     _execute = execute;
+    _canExecute = canExecute;
+    _action = action;
   }
-
-  /// <inheritdoc/>
-  public bool IsCancellationRequested => _cts?.IsCancellationRequested ?? false;
-
-  /// <inheritdoc/>
-  public IActionCommand CancelCommand => new ActionCommand(Cancel, () => _isExecuting);
-
-  /// <inheritdoc/>
-  public event EventHandler? CanExecuteChanged;
 
   /// <inheritdoc/>
   public bool CanExecute()
     => CanExecute(null);
 
   /// <inheritdoc/>
-  public void Cancel()
-  {
-    _cts?.Cancel();
-    RaiseCanExecuteChanged();
-  }
+  public bool CanExecute(object? parameter)
+    => !IsExecuting && (_canExecute?.Invoke() ?? true);
 
   /// <inheritdoc/>
   public Task ExecuteAsync()
@@ -73,34 +69,12 @@ public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecut
       return;
     }
 
-    using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-    _cts = cts;
-
-    try
-    {
-      _isExecuting = true;
-      RaiseCanExecuteChanged();
-      await _execute(cts.Token);
-    }
-    finally
-    {
-      _isExecuting = false;
-      _cts = null;
-      RaiseCanExecuteChanged();
-    }
+    await ExecuteCoreAsync(_execute, cancellationToken);
   }
-
-  /// <inheritdoc/>
-  public bool CanExecute(object? parameter)
-    => !_isExecuting && (_canExecute?.Invoke() ?? true);
 
   /// <inheritdoc/>
   public void Execute(object? parameter)
     => ExecuteAsync().FireAndForgetSafeAsync(_action);
-
-  /// <inheritdoc/>
-  public void RaiseCanExecuteChanged()
-    => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
 }
 
 /// <summary>
@@ -108,22 +82,29 @@ public sealed class AsyncActionCommand(Func<Task> execute, Func<bool>? canExecut
 /// and queried for its ability to execute.
 /// </summary>
 /// <remarks>
-/// When a <c>Func&lt;T, CancellationToken, Task&gt;</c> delegate is supplied the command manages its own
-/// <see cref="CancellationTokenSource"/> internally. Call <see cref="Cancel"/> (or execute
-/// <see cref="CancelCommand"/>) to cancel a running operation.
+/// The command manages its own <see cref="CancellationTokenSource"/> internally. Call
+/// <see cref="AsyncActionCommandBase.Cancel"/> (or execute
+/// <see cref="AsyncActionCommandBase.CancelCommand"/>) to cancel a running operation.
 /// </remarks>
 /// <typeparam name="T">The generic type to work with.</typeparam>
-/// <param name="execute">The task to execute (without cancellation token).</param>
-/// <param name="canExecute">The condition to execute.</param>
-/// <param name="action">The action to invoke if an exception occurs.</param>
-public sealed class AsyncActionCommand<T>(Func<T, Task> execute, Func<T, bool>? canExecute = null, Action<Exception>? action = null) : IAsyncActionCommand<T>
+public sealed class AsyncActionCommand<T> : AsyncActionCommandBase, IAsyncActionCommand<T>
 {
-  private readonly Func<T, CancellationToken, Task> _execute = (p, _) => execute(p);
-  private readonly Func<T, bool>? _canExecute = canExecute;
-  private readonly Action<Exception>? _action = action;
+  private readonly Func<T, CancellationToken, Task> _execute;
+  private readonly Func<T, bool>? _canExecute;
+  private readonly Action<Exception>? _action;
 
-  private bool _isExecuting;
-  private CancellationTokenSource? _cts;
+  /// <summary>
+  /// Initializes a new instance of <see cref="AsyncActionCommand{T}"/>.
+  /// </summary>
+  /// <param name="execute">The task to execute (without cancellation token).</param>
+  /// <param name="canExecute">The condition to execute.</param>
+  /// <param name="action">The action to invoke if an exception occurs.</param>
+  public AsyncActionCommand(Func<T, Task> execute, Func<T, bool>? canExecute = null, Action<Exception>? action = null)
+  {
+    _execute = (parameter, _) => execute(parameter);
+    _canExecute = canExecute;
+    _action = action;
+  }
 
   /// <summary>
   /// Initializes a new instance of <see cref="AsyncActionCommand{T}"/> with a cancellable execute delegate.
@@ -132,38 +113,19 @@ public sealed class AsyncActionCommand<T>(Func<T, Task> execute, Func<T, bool>? 
   /// <param name="canExecute">The condition to execute.</param>
   /// <param name="action">The action to invoke if an exception occurs.</param>
   public AsyncActionCommand(Func<T, CancellationToken, Task> execute, Func<T, bool>? canExecute = null, Action<Exception>? action = null)
-    : this((p) => execute(p, CancellationToken.None), canExecute, action)
   {
     _execute = execute;
+    _canExecute = canExecute;
+    _action = action;
   }
-
-  /// <inheritdoc/>
-  public bool IsCancellationRequested => _cts?.IsCancellationRequested ?? false;
-
-  /// <inheritdoc/>
-  public IActionCommand CancelCommand => new ActionCommand(Cancel, () => _isExecuting);
-
-  /// <inheritdoc/>
-  public event EventHandler? CanExecuteChanged;
 
   /// <inheritdoc/>
   public bool CanExecute(T parameter)
-    => !_isExecuting && (_canExecute?.Invoke(parameter) ?? true);
-
-  /// <inheritdoc/>
-  public void Cancel()
-  {
-    _cts?.Cancel();
-    RaiseCanExecuteChanged();
-  }
+    => !IsExecuting && (_canExecute?.Invoke(parameter) ?? true);
 
   /// <inheritdoc/>
   public bool CanExecute(object? parameter)
     => CanExecute((T)parameter!);
-
-  /// <inheritdoc/>
-  public void Execute(object? parameter)
-    => ExecuteAsync((T)parameter!).FireAndForgetSafeAsync(_action);
 
   /// <inheritdoc/>
   public Task ExecuteAsync(T parameter)
@@ -178,24 +140,10 @@ public sealed class AsyncActionCommand<T>(Func<T, Task> execute, Func<T, bool>? 
       return;
     }
 
-    using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-    _cts = cts;
-
-    try
-    {
-      _isExecuting = true;
-      RaiseCanExecuteChanged();
-      await _execute(parameter, cts.Token);
-    }
-    finally
-    {
-      _isExecuting = false;
-      _cts = null;
-      RaiseCanExecuteChanged();
-    }
+    await ExecuteCoreAsync(token => _execute(parameter, token), cancellationToken);
   }
 
   /// <inheritdoc/>
-  public void RaiseCanExecuteChanged()
-    => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+  public void Execute(object? parameter)
+    => ExecuteAsync((T)parameter!).FireAndForgetSafeAsync(_action);
 }

--- a/src/BB84.Notifications/Commands/AsyncActionCommandBase.cs
+++ b/src/BB84.Notifications/Commands/AsyncActionCommandBase.cs
@@ -1,0 +1,94 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.Notifications.Interfaces.Commands;
+
+namespace BB84.Notifications.Commands;
+
+/// <summary>
+/// Provides the cancellation state and execution pipeline shared by the asynchronous commands.
+/// </summary>
+/// <remarks>
+/// This class owns the <see cref="CancellationTokenSource"/> of the running operation, the
+/// executing flag that suppresses re-entrant execution, and the cancel command. The cancel
+/// command is created once per instance so that subscribers to its
+/// <see cref="System.Windows.Input.ICommand.CanExecuteChanged"/> event survive, and it is
+/// notified whenever the owning command's executability changes.
+/// </remarks>
+public abstract class AsyncActionCommandBase
+{
+  private readonly ActionCommand _cancelCommand;
+  private CancellationTokenSource? _cts;
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="AsyncActionCommandBase"/> class.
+  /// </summary>
+  protected AsyncActionCommandBase()
+    => _cancelCommand = new ActionCommand(Cancel, () => IsExecuting);
+
+  /// <inheritdoc cref="IAsyncActionCommand.IsCancellationRequested"/>
+  public bool IsCancellationRequested => _cts?.IsCancellationRequested ?? false;
+
+  /// <inheritdoc cref="IAsyncActionCommand.CancelCommand"/>
+  /// <remarks>
+  /// The same instance is returned for the lifetime of this command, so handlers attached to
+  /// its <see cref="System.Windows.Input.ICommand.CanExecuteChanged"/> event stay attached.
+  /// </remarks>
+  public IActionCommand CancelCommand => _cancelCommand;
+
+  /// <inheritdoc cref="System.Windows.Input.ICommand.CanExecuteChanged"/>
+  public event EventHandler? CanExecuteChanged;
+
+  /// <summary>
+  /// Gets a value indicating whether an operation is currently running.
+  /// </summary>
+  protected bool IsExecuting { get; private set; }
+
+  /// <inheritdoc cref="IAsyncActionCommand.Cancel"/>
+  public void Cancel()
+  {
+    _cts?.Cancel();
+    RaiseCanExecuteChanged();
+  }
+
+  /// <inheritdoc cref="IAsyncActionCommand.RaiseCanExecuteChanged"/>
+  /// <remarks>
+  /// Also notifies <see cref="CancelCommand"/>, whose executability tracks this command's.
+  /// </remarks>
+  public void RaiseCanExecuteChanged()
+  {
+    CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    _cancelCommand.RaiseCanExecuteChanged();
+  }
+
+  /// <summary>
+  /// Runs the supplied operation, tracking the executing state and exposing a cancellable token.
+  /// </summary>
+  /// <remarks>
+  /// The token handed to <paramref name="body"/> is linked to <paramref name="cancellationToken"/>,
+  /// so the operation is cancelled either by the caller's token or by <see cref="Cancel"/>.
+  /// </remarks>
+  /// <param name="body">The operation to run.</param>
+  /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+  /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+  protected async Task ExecuteCoreAsync(Func<CancellationToken, Task> body, CancellationToken cancellationToken)
+  {
+    using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    _cts = cts;
+
+    try
+    {
+      IsExecuting = true;
+      RaiseCanExecuteChanged();
+      await body(cts.Token);
+    }
+    finally
+    {
+      IsExecuting = false;
+      _cts = null;
+      RaiseCanExecuteChanged();
+    }
+  }
+}

--- a/tests/BB84.Notifications.Tests/Commands/AsyncActionCommandTests.CancelCommand.cs
+++ b/tests/BB84.Notifications.Tests/Commands/AsyncActionCommandTests.CancelCommand.cs
@@ -1,0 +1,134 @@
+// Copyright: 2023 Robert Peter Meyer
+// License: MIT
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+using BB84.Notifications.Commands;
+using BB84.Notifications.Interfaces.Commands;
+
+namespace BB84.Notifications.Tests.Commands;
+
+public sealed partial class AsyncActionCommandTests
+{
+  [TestMethod]
+  public void CancelCommandReturnsTheSameInstance()
+  {
+    AsyncActionCommand command = new(() => Task.CompletedTask);
+
+    IActionCommand first = command.CancelCommand;
+    IActionCommand second = command.CancelCommand;
+
+    Assert.AreSame(first, second);
+  }
+
+  [TestMethod]
+  public void CancelCommandGenericReturnsTheSameInstance()
+  {
+    AsyncActionCommand<int> command = new(p => Task.CompletedTask);
+
+    IActionCommand first = command.CancelCommand;
+    IActionCommand second = command.CancelCommand;
+
+    Assert.AreSame(first, second);
+  }
+
+  [TestMethod]
+  public async Task CancelCommandNotifiesSubscribersWhileExecuting()
+  {
+    TaskCompletionSource<bool> started = new();
+    TaskCompletionSource<bool> release = new();
+    AsyncActionCommand command = new(async ct =>
+    {
+      started.SetResult(true);
+      await release.Task;
+    });
+
+    int notifications = 0;
+    IActionCommand cancelCommand = command.CancelCommand;
+    cancelCommand.CanExecuteChanged += (s, e) => notifications++;
+
+    Task execution = command.ExecuteAsync();
+    await started.Task;
+
+    // A cancel button bound to CancelCommand has to be told it became enabled.
+    Assert.IsTrue(notifications > 0);
+
+    release.SetResult(true);
+    await execution;
+  }
+
+  [TestMethod]
+  public async Task CancelCommandCanExecuteTracksTheExecutionState()
+  {
+    TaskCompletionSource<bool> started = new();
+    TaskCompletionSource<bool> release = new();
+    AsyncActionCommand command = new(async ct =>
+    {
+      started.SetResult(true);
+      await release.Task;
+    });
+
+    IActionCommand cancelCommand = command.CancelCommand;
+
+    Assert.IsFalse(cancelCommand.CanExecute());
+
+    Task execution = command.ExecuteAsync();
+    await started.Task;
+
+    Assert.IsTrue(cancelCommand.CanExecute());
+
+    release.SetResult(true);
+    await execution;
+
+    Assert.IsFalse(cancelCommand.CanExecute());
+  }
+
+  [TestMethod]
+  public async Task CancelCommandRetainedBeforeExecutionStillCancels()
+  {
+    TaskCompletionSource<bool> started = new();
+    bool wasCancelled = false;
+    AsyncActionCommand command = new(async ct =>
+    {
+      started.SetResult(true);
+      try { await Task.Delay(5000, ct); }
+      catch (OperationCanceledException) { wasCancelled = true; throw; }
+    });
+
+    // Retaining the reference up front is what a binding does.
+    IActionCommand cancelCommand = command.CancelCommand;
+
+    Task execution = command.ExecuteAsync();
+    await started.Task;
+
+    cancelCommand.Execute();
+
+    try { await execution; } catch (OperationCanceledException) { }
+
+    Assert.IsTrue(wasCancelled);
+  }
+
+  [TestMethod]
+  public async Task CancelCommandGenericNotifiesSubscribersWhileExecuting()
+  {
+    TaskCompletionSource<bool> started = new();
+    TaskCompletionSource<bool> release = new();
+    AsyncActionCommand<int> command = new(async (p, ct) =>
+    {
+      started.SetResult(true);
+      await release.Task;
+    });
+
+    int notifications = 0;
+    IActionCommand cancelCommand = command.CancelCommand;
+    cancelCommand.CanExecuteChanged += (s, e) => notifications++;
+
+    Task execution = command.ExecuteAsync(1);
+    await started.Task;
+
+    Assert.IsTrue(notifications > 0);
+
+    release.SetResult(true);
+    await execution;
+  }
+}


### PR DESCRIPTION
**Changes:**

`CancelCommand` was an expression-bodied property constructing a new `ActionCommand` on every read, so anything subscribing to its `CanExecuteChanged` event subscribed to a throwaway that was collected immediately. A cancel button bound to it never learned it had become enabled, and reference equality never held between two reads.

The cancel command is now created once per owning command, and `RaiseCanExecuteChanged` forwards to it so its executability actually tracks the operation.

The two async command types were near-duplicates, which is why this bug existed twice. The cancellation state, the cached cancel command and the linked-CTS execute pipeline now live in `AsyncActionCommandBase`, so both types share one copy.

The cancellable constructors no longer chain through the non-cancellable ones, which allocated a closure that was overwritten on the next line.

Known limitation, unchanged: Cancel can still observe a `CancellationTokenSource` that `ExecuteAsync`'s using block is concurrently disposing.

closes #207 